### PR TITLE
Encoding suspects

### DIFF
--- a/gitprep.conf
+++ b/gitprep.conf
@@ -20,6 +20,11 @@
 ;time_zone=+10:30
 ;time_zone=-4:00
 
+;;; Suspects encoding list for source code character encoding (default:UTF-8)
+;;; set comma separated encoding list if your source code is different from UTF-8.
+;;; encoding name follow Perl encoding API.
+;encoding_suspects=cp932,utf8
+
 [admin]
 ;;; If you forget admin password,
 ;;; set this value to 1 and access /reset-password page.

--- a/lib/Gitprep.pm
+++ b/lib/Gitprep.pm
@@ -56,6 +56,12 @@ sub startup {
   }
   $git->bin($git_bin);
   
+  # Encoding suspects list for Git
+  my $encoding_suspects
+    = $conf->{basic}{encoding_suspects} ||= 'utf8';
+  $encoding_suspects = [split /,/, $encoding_suspects] unless ref $encoding_suspects eq 'ARRAY';
+  $git->encoding_suspects($encoding_suspects);
+
   # Repository Manager
   my $manager = Gitprep::Manager->new(app => $self);
   weaken $manager->{app};

--- a/lib/Gitprep/Git.pm
+++ b/lib/Gitprep/Git.pm
@@ -3,6 +3,7 @@ use Mojo::Base -base;
 
 use Carp 'croak';
 use Encode qw/encode decode/;
+use Encode::Guess;
 use Fcntl ':mode';
 use File::Basename qw/basename dirname/;
 use File::Copy 'move';
@@ -13,6 +14,7 @@ use POSIX 'floor';
 # Attributes
 has 'bin';
 has default_encoding => 'UTF-8';
+has 'encoding_suspects';
 has 'rep_home';
 has text_exts => sub { ['txt'] };
 has 'time_zone_second';
@@ -181,7 +183,7 @@ sub blame {
   my $blame_line;
   my $max_author_time;
   my $min_author_time;
-  while (my $line = $self->_dec(scalar <$fh>)) {
+  while (my $line = $self->_dec_guess(scalar <$fh>)) {
     chomp $line;
     
     if ($blame_line) {
@@ -258,7 +260,7 @@ sub blob {
   
   # Format lines
   my $lines =[];
-  while (my $line = $self->_dec(scalar <$fh>)) {
+  while (my $line = $self->_dec_guess(scalar <$fh>)) {
     chomp $line;
     push @$lines, $line;
   }
@@ -287,7 +289,7 @@ sub blob_diffs {
   open my $fh, '-|', @cmd
     or croak('Open self-diff-tree failed');
   my @diff_tree;
-  while (my $line = $self->_dec(scalar <$fh>)) {
+  while (my $line = $self->_dec_guess(scalar <$fh>)) {
     chomp $line;
     push @diff_tree, $line if $line =~ /^:/;
     last if $line =~ /^\n/;
@@ -320,7 +322,7 @@ sub blob_diffs {
     );
     open my $fh, '-|', @cmd
       or croak('Open self-diff-tree failed');
-    my @lines = map { $self->_dec($_) } <$fh>;
+    my @lines = map { $self->_dec_guess($_) } <$fh>;
     close $fh;
     my ($lines, $diff_info) = $self->parse_blob_diff_lines(\@lines);
     my $blob_diff = {
@@ -1670,6 +1672,20 @@ sub _chop_str {
     }
     return "$body$tail";
   }
+}
+
+sub _dec_guess {
+  my ($self, $str) = @_;
+
+  my $enc = Encode::Guess->guess($str, @{$self->encoding_suspects});
+  # fallback default encoding if multile guess result
+  # http://perl-users.jp/articles/advent-calendar/2009/casual/10.html
+  $enc = $self->default_encoding unless ref $enc;
+
+  my $new_str;
+  eval { $new_str = decode($enc, $str) };
+
+  return $@ ? $str : $new_str;
 }
 
 sub _dec {


### PR DESCRIPTION
specific character encoding support for commit diff, normal blob and blame view.

I have tested with Shift-JIS(cp932) source code.
This uses Encode::Guess to determine source code encoding.
It could be text processing slower but I didn't feel speed difference.

This add a config parameter "encoding_suspects" to set list of suspects.
I didn't tested the other encoding (e.g. latin1) but It should work in the same way.

Thanks,
-- Tetsuya
