### PR TITLE
add image support for markdown

### DIFF
--- a/templates/blob.html.ep
+++ b/templates/blob.html.ep
@@ -92,6 +92,8 @@
     % } elsif ($mime_type =~ m#^text/#) {
       % if ($file =~ /\.md$/) {
         % my $readme = join "\n", @$lines;
+        % $readme =~ s#^(\[.*\]:)(?!\s*https?://)\s*(\S*)#$1 /$user/$project/raw/$rev/$2#mg;
+        % $readme =~ s#^(!\[.*\]\()(?!https?://)(\S*)#$1/$user/$project/raw/$rev/$2#mg;
         % my $readme_e = Text::Markdown::Hoedown::markdown($readme, extensions => HOEDOWN_EXT_FENCED_CODE);
         <div class="markdown border-gray">
           <%== $readme_e %>

--- a/templates/include/readme.html.ep
+++ b/templates/include/readme.html.ep
@@ -13,6 +13,8 @@
   if ($lines) {
     $type = 'plain';
     my $readme = join "\n", @$lines;
+    $readme =~ s#^(\[.*\]:)(?!\s*https?://)\s*(\S*)#$1 /$user/$project/raw/$rev/$2#mg;
+    $readme =~ s#^(!\[.*\]\()(?!https?://)(\S*)#$1/$user/$project/raw/$rev/$2#mg;
     $readme_e = Mojo::ByteStream->new($readme)->xml_escape->to_string;
     $readme_e =~ s#(^|\s|[^\x00-\x7F])(http(?:s)?://.+?)($|\s|[^\x00-\x7F])#$1<a href="$2">$2</a>$3#msg;
   }


### PR DESCRIPTION
support image display on gitprep
Change the markdown image path to gitprep path before render the markdown to html
Do not change the path if the image path is http/https link form other site