### PR TITLE
fix: Issue #117 (labels not generated for new repositories)

### DIFF
--- a/templates/issues.html.ep
+++ b/templates/issues.html.ep
@@ -35,7 +35,7 @@
   my $close_count = $api->get_close_issue_count($user_id, $project_id);
   
   # Initialize labels if there are no labels
-  my $labels_count = app->dbi->model('label')->select('count(*)')->value;
+  my $labels_count = app->dbi->model('label')->select('count(*)', where => {'project.id' => $project_id})->value;
   if ($labels_count == 0) {
     my @labels = (
       {id => 'bug', color => '#fc2929'},

--- a/templates/issues.html.ep
+++ b/templates/issues.html.ep
@@ -35,7 +35,7 @@
   my $close_count = $api->get_close_issue_count($user_id, $project_id);
   
   # Initialize labels if there are no labels
-  my $labels_count = app->dbi->model('label')->select('count(*)', where => {'project.id' => $project_id})->value;
+  my $labels_count = app->dbi->model('label')->select('count(*)', where => {'user.id' => $user_id, 'project.id' => $project_id})->value;
   if ($labels_count == 0) {
     my @labels = (
       {id => 'bug', color => '#fc2929'},


### PR DESCRIPTION
In _/templates/issues.html.ep_ on **line 47** the query checks for **any** available labels, regardless if these labels belong to the particular project or not:

`my $labels_count = app->dbi->model('label')->select('count(*)')->value;`

Changing the query to the following fixes the problem:

`my $labels_count = app->dbi->model('label')->select('count(*)', where => {'project.id' => $project_id})->value;`