### PR TITLE
Issue #141: Insert markdown buttons fix on new.html.ep

### DIFF
--- a/templates/issues/new.html.ep
+++ b/templates/issues/new.html.ep
@@ -102,9 +102,14 @@
   layout 'common', title => "New issue - $user_id/$project_id";
 %>
 
+%= javascript '/js/icon-input.js';
+
 %= javascript begin
   $(document).ready(function() {
     %= include '/include/js/issue';
+    
+    // Initialize icon input
+    init_icon_input();
   });
 % end
 


### PR DESCRIPTION
Insert markdown buttons on the new issue page now work.
icon-input.js included and initiated the same way as it is on issue.html.ep

Fix for issue #141