### PR TITLE
Added instructions to build GitPrep docker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,33 @@ Caveat - this installation method is only supported for Linux OS.
 
 Follow [Sparrowdo](https://github.com/melezhik/sparrowdo) for the details.
 
+**Dockerfile and docker-compose**
+
+You can use Docker to build your own container based on Alpine Linux. This image configures SSHD to be run by user root and GitPrep to be run by user gitprep.
+
+    docker build ./deploy -t jndeverteuil/gitprep:latest
+
+With that build, you can start a service with docker-compose:
+
+    version: "3"
+
+    services:
+    gitprep:
+        image: jndeverteuil/gitprep:latest
+        container_name: gitprep
+        hostname: gitprep
+        restart: always
+        ports:
+        - "10020:10020"
+        - "0.0.0.0:2222:22"
+        volumes:
+        - gitprep:/home/gitprep
+        - sshd:/etc/ssh
+
+    volumes:
+    gitprep:
+    sshd:
+
 ## For Developers
 
 ### Run GitPrep in development mode

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,76 @@
+FROM alpine:3.9
+
+# Update OS and install dependencies
+RUN set -x \
+    && apk update \
+    && apk upgrade \
+    && apk --no-cache add \
+        tini \
+        bash \
+        shadow \
+        perl \
+        git \
+        openssh-server \
+        perl-dev \
+        gcc \
+        g++ \
+        curl \
+        wget \
+        make
+
+# Create user gitprep
+RUN set -x \
+    && useradd -m gitprep \
+    && mkdir -m 700 /home/gitprep/.ssh \
+    && usermod -p '*' gitprep \
+    && touch /home/gitprep/.ssh/authorized_keys \
+    && chmod 600 /home/gitprep/.ssh/authorized_keys \
+    && chown -R gitprep:gitprep /home/gitprep/.ssh \
+    && sed -i 's/#PasswordAuthentication yes.*/PasswordAuthentication no/' /etc/ssh/sshd_config \
+    && sed -i 's/#ChallengeResponseAuthentication yes.*/ChallengeResponseAuthentication no /' /etc/ssh/sshd_config
+
+USER gitprep
+
+# Install GitPrep
+RUN set -x \
+    && git --version \
+    && perl -v \
+    && curl -kL https://github.com/yuki-kimoto/gitprep/archive/latest.tar.gz \
+        > /home/gitprep/gitprep-latest.tar.gz \
+    && mkdir /home/gitprep/gitprep \
+    && tar -zxf /home/gitprep/gitprep-latest.tar.gz \
+        --strip-components=1 -C /home/gitprep/gitprep \
+    && rm -f /home/gitprep/gitprep-latest.tar.gz \
+    && cd /home/gitprep/gitprep \
+    && PERL_USE_UNSAFE_INC=1 ./setup_module \
+    && prove t \
+    && ./setup_database
+
+USER root
+
+# Clean obsolete Packages
+RUN set -x \
+    && apk del --no-cache \
+        perl-dev \
+        gcc \
+        g++ \
+        curl \
+        wget \
+        make
+
+# Copy start script
+COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod 700 /docker-entrypoint.sh
+
+# Expose default HTTP connector port.
+EXPOSE 10020
+EXPOSE 22
+
+# Set volume mount point
+VOLUME ["/home/gitprep"]
+
+# Set the default working directory as the installation directory.
+WORKDIR /home/gitprep
+
+# Set entrypoint to invoke tini as PID1
+ENTRYPOINT ["/sbin/tini","--","/docker-entrypoint.sh"]

--- a/deploy/docker-entrypoint.sh
+++ b/deploy/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Making all required files if they are not existing.
+test -f /etc/ssh/ssh_host_ecdsa_key || \
+    /usr/bin/ssh-keygen -q -t ecdsa -f /etc/ssh/ssh_host_ecdsa_key -C '' -N ''
+test -f /etc/ssh/ssh_host_rsa_key || \
+    /usr/bin/ssh-keygen -q -t rsa -f /etc/ssh/ssh_host_rsa_key -C '' -N ''
+test -f /etc/ssh/ssh_host_ed25519_key || \
+    /usr/bin/ssh-keygen -q -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -C '' -N ''
+
+# Now start SSH daemon.
+/usr/sbin/sshd
+
+# GitPrep restrict max post message size 10MB(This is default of Mojolicious)
+# We overwrite the value to 1GB :
+export MOJO_MAX_MESSAGE_SIZE=1024000000 
+
+# Start GitPrep and tail log file
+su - gitprep -s /bin/bash -c '/home/gitprep/gitprep/gitprep'
+tail -f /home/gitprep/gitprep/log/production.log


### PR DESCRIPTION
Adds instructions to build and run GitPrep as a **Docker service with docker-compose** based on an Alpine Linux image.

I also provided the **Dockerfile** with it's docker-entrypoint.sh (in ./deploy) to build a GitPrep docker container that works out-of-the-box with SSH.

The docker-compose.yml file I presented use SSH port 2222 to differentiate with the container host SSH port.

Once built, the docker image is ~287MB.

Cheers!