### PR TITLE
Use rewrite rules instead of file access rules in Apache configuration

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,9 +1,9 @@
-deny from all
+Options +ExecCGI
+AddHandler cgi-script .cgi
 
-<Files ~ "gitprep\.cgi">
-allow from all
-</Files>
+RewriteEngine On
+
+RewriteRule "^$" "gitprep.cgi"
+RewriteRule "!^gitprep\.cgi(\/|$)" "" [F]
 
 SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
-
-DirectoryIndex index.cgi


### PR DESCRIPTION
I have tried to install Gitprep on a shared server, with the LAMP stack provided through Plesk. The Plesk stack includes a security package called fail2ban, which bans IP addresses that trigger specific security rules.  

The  `.htaccess` file distributed with Gitprep has security rules that cause an error of code AH01797  in the Apache logs. When fail2ban reads the log, it triggers a security rule. Then Gtiprep cannot be used in this environment.

Gitprep is ideal for  shared servers, because it is CGI only, without  a standalone server component.

Therefore, it is useful if the `.htaccess` file is compatible.

I have found that using rewrite rules instead of access rules, the application works correctly, with the same security, and better compatibility. I have not tested rigorously, but had  success with on my deployment.

I also added declarations for CGI handling, since many shared hosting sites do not handle CGI executables by default. Including the declarations with the application simplifies deployment in these environments.

