### PR TITLE
Using temporary container to build dependencies

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.9
+FROM alpine:3.9 as BUILDER
 
 # Update OS and install dependencies
 RUN set -x \
@@ -9,8 +9,6 @@ RUN set -x \
         bash \
         shadow \
         perl \
-        git \
-        openssh-server \
         perl-dev \
         gcc \
         g++ \
@@ -18,23 +16,9 @@ RUN set -x \
         wget \
         make
 
-# Create user gitprep
-RUN set -x \
-    && useradd -m gitprep \
-    && mkdir -m 700 /home/gitprep/.ssh \
-    && usermod -p '*' gitprep \
-    && touch /home/gitprep/.ssh/authorized_keys \
-    && chmod 600 /home/gitprep/.ssh/authorized_keys \
-    && chown -R gitprep:gitprep /home/gitprep/.ssh \
-    && sed -i 's/#PasswordAuthentication yes.*/PasswordAuthentication no/' /etc/ssh/sshd_config \
-    && sed -i 's/#ChallengeResponseAuthentication yes.*/ChallengeResponseAuthentication no /' /etc/ssh/sshd_config
-
-USER gitprep
-
 # Install GitPrep
 RUN set -x \
-    && git --version \
-    && perl -v \
+    && mkdir -m 700 /home/gitprep \
     && curl -kL https://github.com/yuki-kimoto/gitprep/archive/latest.tar.gz \
         > /home/gitprep/gitprep-latest.tar.gz \
     && mkdir /home/gitprep/gitprep \
@@ -46,17 +30,31 @@ RUN set -x \
     && prove t \
     && ./setup_database
 
-USER root
+FROM alpine:3.9
 
-# Clean obsolete Packages
 RUN set -x \
-    && apk del --no-cache \
-        perl-dev \
-        gcc \
-        g++ \
-        curl \
-        wget \
-        make
+    && apk update \
+    && apk upgrade \
+    && apk --no-cache add \
+        tini \
+        bash \
+        shadow \
+        perl \
+        git \
+        openssh-server
+
+# Create user gitprep
+RUN set -x \
+    && useradd -m gitprep \
+    && mkdir -p -m 700 /home/gitprep/.ssh \
+    && usermod -p '*' gitprep \
+    && touch /home/gitprep/.ssh/authorized_keys \
+    && chmod 600 /home/gitprep/.ssh/authorized_keys \
+    && chown -R gitprep:gitprep /home/gitprep/.ssh \
+    && sed -i 's/#PasswordAuthentication yes.*/PasswordAuthentication no/' /etc/ssh/sshd_config \
+    && sed -i 's/#ChallengeResponseAuthentication yes.*/ChallengeResponseAuthentication no /' /etc/ssh/sshd_config
+
+COPY --chown=gitprep:gitprep --from=BUILDER /home/gitprep/gitprep /home/gitprep/gitprep
 
 # Copy start script
 COPY ./docker-entrypoint.sh /docker-entrypoint.sh


### PR DESCRIPTION
Hello.
I've made some modifications in the Docker file. Now it uses temporary container to build and install dependencies and a clean container to run the app.
This allowed to shrink the image more than twice in size:

```
gitprep-builder         latest      c151d79ccf6d        12 minutes ago      127MB
gitprep-orginal         latest      f7eb28e76d05        About an hour ago   288MB
```   