### PR TITLE
fixed issues with placeholders

### DIFF
--- a/script/stop_gitprep.sh
+++ b/script/stop_gitprep.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+ps aux | grep gitprep | awk '{print $2}' | xargs kill -INT
+

--- a/templates/user-settings/ssh.html.ep
+++ b/templates/user-settings/ssh.html.ep
@@ -83,6 +83,9 @@
           else {
             my $key_is_contained;
             my $authorized_keys_file = app->manager->authorized_keys_file;
+            unless (-f $authorized_keys_file && -w $authorized_keys_file) {
+                die "ERROR: $authorized_keys_file does not exist or is not writable: $!";
+            }
             if (defined $authorized_keys_file) {
               my $result
                 = app->manager->parse_authorized_keys_file($authorized_keys_file);


### PR DESCRIPTION
( and ) were replaced in later versions of Mojo with < and > for the purpose of quoting placeholders, so /:user/(#project).git should be /:user/(<#project>.git ; fixed all routes defined in lib/Gitprep.pm 

found the issue when testing downloading archives and trying to clone a project using http 