### PR TITLE
Enable ssh accesses using an scp-like relative "url".

### DIFF
--- a/script/gitprep-shell-raw
+++ b/script/gitprep-shell-raw
@@ -79,7 +79,7 @@ sub parse_ssh_original_command {
   $ssh_original_command ||= '';
 
   my $git_commands = "git-upload-pack|git-receive-pack|git-upload-archive";
-  if ($ssh_original_command =~ m(^($git_commands) '.*/($user_re)/([^\/]+?)\.git'$)) {
+  if ($ssh_original_command =~ m(^($git_commands) '(?:.*/)?($user_re)/([^\/]+?)\.git'$)) {
     my ($verb, $user_id, $project_id) = ($1, $2, $3);
     warn "User:$user_id, Project:$project_id" if $debug;
     die "invalid repo name: '$project_id'\n" if $project_id !~ $project_re;


### PR DESCRIPTION
Accesses can be made by git using an scp-like _url_ syntax (i.e.: `git@server:user/repo.git`) without a leading `/` (home-relative path). The syntax accepted by the gitprep shell is therefore extended by this commit to allow these.

Thanks for considering it.