### PR TITLE
Prefer markdown display if both README file versions are present

### DIFF
--- a/templates/include/readme.html.ep
+++ b/templates/include/readme.html.ep
@@ -7,27 +7,27 @@
   
   # README
   my $type = '';
+  my $readme_e;
   my $lines;
   my $readme_path = (defined $dir && $dir ne '') ? "$dir/README" : 'README';
-  eval { $lines = app->git->blob(app->rep_info($user, $project), $rev, $readme_path) };
-  my $readme_e;
-  
+  eval { $lines = app->git->blob(app->rep_info($user, $project), $rev, "$readme_path.md") };
   if ($lines) {
-    $type = 'plain';
+    $type = 'markdown';
     my $readme = join "\n", @$lines;
-    $readme_e = Mojo::ByteStream->new($readme)->xml_escape->to_string;
-    $readme_e =~ s#(^|\s|[^\x00-\x7F])(http(?:s)?://.+?)($|\s|[^\x00-\x7F])#$1<a href="$2">$2</a>$3#msg;
+    $readme =~ s#^(\[.*\]:)(?!\s*https?://)\s*(\S*)#{"$1 " . url_for("/$user/$project/raw/$rev/$2")}#mge;
+    $readme =~ s#^(!\[.*\]\()(?!https?://)(\S*)#{$1 . url_for("/$user/$project/raw/$rev/$2")}#mge;
+    $readme =~ s#src="(?!https?://)(\S*)"#{'src="' . url_for("/$user/$project/raw/$rev/$1") . '"'}#mge;
+
+    $readme_e = $api->markdown($readme);
   }
   else {
-    eval { $lines = app->git->blob(app->rep_info($user, $project), $rev, "$readme_path.md") };
+    eval { $lines = app->git->blob(app->rep_info($user, $project), $rev, $readme_path) };
+
     if ($lines) {
-      $type = 'markdown';
+      $type = 'plain';
       my $readme = join "\n", @$lines;
-      $readme =~ s#^(\[.*\]:)(?!\s*https?://)\s*(\S*)#{"$1 " . url_for("/$user/$project/raw/$rev/$2")}#mge;
-      $readme =~ s#^(!\[.*\]\()(?!https?://)(\S*)#{$1 . url_for("/$user/$project/raw/$rev/$2")}#mge;
-      $readme =~ s#src="(?!https?://)(\S*)"#{'src="' . url_for("/$user/$project/raw/$rev/$1") . '"'}#mge;
-      
-      $readme_e = $api->markdown($readme);
+      $readme_e = Mojo::ByteStream->new($readme)->xml_escape->to_string;
+      $readme_e =~ s#(^|\s|[^\x00-\x7F])(http(?:s)?://.+?)($|\s|[^\x00-\x7F])#$1<a href="$2">$2</a>$3#msg;
     }
   }
 %>


### PR DESCRIPTION
This commit reverses the checking order of README and README.md to show the latter instead of the former if both exist in the displayed directory.