### PR TITLE
Improve icon input on comments.

### DIFF
--- a/public/js/icon-input.js
+++ b/public/js/icon-input.js
@@ -1,55 +1,110 @@
-function insertAtCaret(target, str) {
-  var obj = $(target);
-  obj.focus();
-  if(navigator.userAgent.match(/MSIE/)) {
-    var r = document.selection.createRange();
-    r.text = str;
-    r.select();
-  } else {
-    var s = obj.val();
-    var p = obj.get(0).selectionStart;
-    var np = p + str.length;
-    obj.val(s.substr(0, p) + str + s.substr(p));
-    obj.get(0).setSelectionRange(np, np);
-  }
-}
-
 function init_icon_input () {
+  var get;
+  var put;
+  var preset;
+
+  if(navigator.userAgent.match(/MSIE/)) {
+    preset = function(obj) {
+      var r = document.selection.createRange();
+      obj.data('iconInputData', {
+        'from': 0,
+        'to': r.text.length,
+        'infix': r.text,
+        'range': r
+      });
+    }
+    get = function(obj) {
+      return obj.data('iconInputData');
+    }
+    put = function(target) {
+      target['range'].text = target['infix'];
+      target['range'].select();
+    }
+  }
+  else {
+    get = function(obj) {
+      var s = obj.val();
+      var p = obj.get(0).selectionStart;
+      var e = obj.get(0).selectionEnd;
+      return {
+        'from': p,
+        'to': e,
+        'prefix': s.substring(0, p),
+        'infix': s.substring(p, e),
+        'suffix': s.substring(e),
+        'obj': obj
+      };
+    }
+    put = function(target) {
+      var obj = target['obj'];
+      obj.val(target['prefix'] + target['infix'] + target['suffix']);
+      obj.get(0).setSelectionRange(target['from'], target['to']);
+    }
+  }
+
+  var iconResponse = function(icon, single, multi, embed) {
+    var textarea = $(icon).closest('form').find('textarea');
+    var obj = $(textarea);
+    obj.focus();
+    var target = get(obj);
+    var sellen = target['infix'].length;
+    var lines = target['infix'].split("\n");
+    if (multi !== undefined && lines.length > 1) {
+      single = multi;
+    }
+    if (embed === undefined) {
+      embed = "\n";
+    }
+    var before = single[0];
+    var after = single[1];
+    if (after === undefined) {
+      after = "";
+    }
+    target['infix'] = before + lines.join(embed) + after;
+    target['to'] += target['infix'].length - sellen - after.length;
+    target['from'] += before.length;
+    put(target);
+  }
+
+  var setEvents = function(iconclass, callback) {
+    var icon = $(iconclass);
+    if (preset) {
+      icon.on('mousedown', function () {
+        var textarea = $(this).closest('form').find('textarea');
+        var obj = $(textarea);
+        obj.focus();
+        preset(obj);
+      });
+    }
+    icon.on('click', callback);
+  }
+
   // Comment icon
-  $('.icon-add-header-text').on('click', function () {
-    var textarea = $(this).closest('form').find('textarea');
-    insertAtCaret(textarea, "# ");
+  setEvents('.icon-add-header-text', function () {
+    iconResponse(this, ["# "]);
   });
-  $('.icon-add-bold-text').on('click', function () {
-    var textarea = $(this).closest('form').find('textarea');
-    insertAtCaret(textarea, "****");
+  setEvents('.icon-add-bold-text', function () {
+    iconResponse(this, ["**", "**"]);
   });
-  $('.icon-add-italic-text').on('click', function () {
-    var textarea = $(this).closest('form').find('textarea');
-    insertAtCaret(textarea, "__");
+  setEvents('.icon-add-italic-text', function () {
+    iconResponse(this, ["_", "_"]);
   });
-  $('.icon-insert-quote').on('click', function () {
-    var textarea = $(this).closest('form').find('textarea');
-    insertAtCaret(textarea, "> ");
+  setEvents('.icon-insert-quote', function () {
+    iconResponse(this, ["> "]);
   });
-  $('.icon-insert-code').on('click', function () {
-    var textarea = $(this).closest('form').find('textarea');
-    insertAtCaret(textarea, "``");
+  setEvents('.icon-insert-code', function () {
+    iconResponse(this, ["`", "`"], ["```\n", "\n```"]);
   });
-  $('.icon-add-link').on('click', function () {
-    var textarea = $(this).closest('form').find('textarea');
-    insertAtCaret(textarea, "[](url)");
+  setEvents('.icon-add-link', function () {
+    iconResponse(this, ["[", "](url)"]);
   });
-  $('.icon-add-bulleted-list').on('click', function () {
-    var textarea = $(this).closest('form').find('textarea');
-    insertAtCaret(textarea, "- ");
+  setEvents('.icon-add-bulleted-list', function () {
+    iconResponse(this, ["- "], undefined, "\n- ");
   });
-  $('.icon-add-numbered-list').on('click', function () {
-    var textarea = $(this).closest('form').find('textarea');
-    insertAtCaret(textarea, "1. ");
+  setEvents('.icon-add-numbered-list', function () {
+    iconResponse(this, ["1. "], undefined, "\n1. ");
   });
-  $('.icon-mention-user').on('click', function () {
-    var textarea = $(this).closest('form').find('textarea');
-    insertAtCaret(textarea, "@");
+  setEvents('.icon-mention-user', function () {
+    iconResponse(this, ["@"]);
   });
 }


### PR DESCRIPTION
If no current text selection, move the caret where data must be entered next. Else insert the selected text where it should be and retain selection.

Multiline selections are checked for use of alternate delimiters and/or embedded line separators.

On MSIE, latch text selection on mousedown event, because it is cleared before click event occurs.

I did'nt succeed in reselecting properly on MSIE, but I don't think it's worth putting more energy for a non-standard discontinued browser (< 2.5% market share). IMHO, MSIE specific code should even be removed. I checked with an old IE11 and gitprep has also other problems on it. That said, even github is almost unusable on IE11!

Thanks for your comments