### PR TITLE
Support for issue comment notification by e-mail and subscription.

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,9 @@ Even if shared hosting server, you can install Mojolicious application as CGI.
     requires 'Mojolicious::Plugin::RequestBase', '== 0.3';
     requires 'Text::Markdown::Hoedown', '== 1.01';
     requires 'Time::Moment', '== 0.38';
+    requires 'MIME::Entity', '== 5.510';
+    requires 'HTML::FormatText::WithLinks', '== 0.15';
+    requires 'Email::Sender', '== 2.600';
 
 If you want to install all defined modules, you only run the following command.
 
@@ -687,6 +690,9 @@ Thanks to Mojolicious author,[Sebastian riedel](https://twitter.com/kraih).
 * [DBI](http://search.cpan.org/dist/DBI/DBI.pm)
 * [DBIx::Connector](http://search.cpan.org/dist/DBIx-Connector/lib/DBIx/Connector.pm)
 * [DBIx::Custom](http://search.cpan.org/dist/DBIx-Custom/lib/DBIx/Custom.pm)
+* [HTML::FormatText::WithLinks](https://metacpan.org/pod/HTML::FormatText::WithLinks)
+* [MIME::Entity](https://metacpan.org/pod/MIME::Entity)
+* [Email::Sender](https://metacpan.org/pod/Email::Sender)
 
 ## Sister project
 

--- a/cpanfile
+++ b/cpanfile
@@ -19,4 +19,7 @@ requires 'Text::Markdown::Hoedown';
 requires 'Time::Moment';
 requires 'Crypt::Digest::SHA256';
 requires 'MIME::Base64';
+requires 'MIME::Entity';
+requires 'HTML::FormatText::WithLinks';
+requires 'Email::Sender';
 

--- a/gitprep.conf.example
+++ b/gitprep.conf.example
@@ -66,3 +66,30 @@ listen=http://127.0.0.1:10020
 ;;; If proxy path is http://somehost.com/foo/bar, you set path_depth to 2.
 ; path_depth=1
 ; path_depth=2
+
+[mail]
+;;; Notifications by e-mail.
+;;; "From" address of e-mails sent. Should not accept incoming mails.
+;;; Default is to disable notifications.
+; from=no-reply@gitprep.org
+
+;;; Dummy (i.e. no reply) visible recipient e-mail address.
+;;; Default: "undisclosed-recipients:;".
+; to=no-reply@gitprep.org
+
+[sendmail]
+;;; Sendmail program path (default: search in $PATH, /usr/sbin and /usr/lib).
+; sendmail=/usr/local/bin/sendmail
+
+[smtp]
+;;; list of space-separated smtp server FQDNs.
+; hosts=mail.gitprep.org
+
+;;; listening port of the smtp server (default: 25).
+; port=587
+
+;;; Authentication user name.
+; sasl_username=gitprep
+
+;;; Authentication password.
+; sasl_password=LetsOpenIt

--- a/public/css/common.css
+++ b/public/css/common.css
@@ -444,6 +444,32 @@ a.wiki-btn-history:hover {
   padding:4px 5px;
   color:#333;
 }
+.issue-subscription {
+  padding-top: 5px;
+  display: block;
+  width: 100%;
+}
+.subscription-btn {
+  display: inline-block;
+  padding: 3px;
+  width: 100%;
+  border-radius: 8px;
+  border-style: solid;
+  border-width: 1px;
+}
+.subscription-btn:hover {
+  background: #d0d0d0;
+}
+.subscription-btn-icon {
+  vertical-align: middle;
+}
+.subscription-btn-text {
+}
+.notif-reason {
+  width: 100%;
+  color: #767676;
+  margin-top: 5px;
+}
 .labels-new-panel {
   text-align:right;
   margin-bottom:20px;

--- a/setup_database
+++ b/setup_database
@@ -339,4 +339,29 @@ EOS
     my $error = "Can't create wiki table properly: $@";
     die $error;
   }
+
+  # Create subscription table
+  eval {
+    my $sql = <<"EOS";
+create table subscription (
+  row_id integer primary key autoincrement,
+  issue integer not null default 0,
+  user integer not null default 0,
+  reason text not null default '',
+  unique(issue, user)
+);
+EOS
+    $dbi->execute($sql);
+  };
+  
+  # Check subscription table
+  eval {
+    $dbi->select(
+      table => 'subscription'
+    );
+  };
+  if ($@) {
+    my $error = "Can't create subscription table properly: $@";
+    die $error;
+  }
 }

--- a/templates/api/notify.html.ep
+++ b/templates/api/notify.html.ep
@@ -1,0 +1,19 @@
+<%
+  # API
+  my $api = gitprep_api;
+
+  # Arguments.
+  my $user = stash('user');
+  my $project = stash('project');
+  my $path_suffix = stash('path_suffix');
+  my $message = stash('message');
+  my $message_id = stash('message_id');
+
+  my $link = url_for("/$user/$project/$path_suffix")->fragment($message_id)->to_abs;
+%>
+
+<div><%== $message %></div>
+<p style="font-size:small;-webkit-text-size-adjust:none;color:#666;">
+  &mdash;<br />
+  <a href="<%= $link %>">View it on Gitprep</a>
+</p>

--- a/templates/api/subscribe.html.ep
+++ b/templates/api/subscribe.html.ep
@@ -1,0 +1,79 @@
+<%
+  # API
+  my $api = gitprep_api;
+
+  return unless $api->logined;
+
+  my $user = param('user');
+  my $project = param('project');
+  my $reason = stash('reason');
+  my $user_row_id = $api->session_user_row_id;
+
+  $reason && $api->subscribe($user_row_id, $issue, $reason);
+
+  $reason = app->dbi->model('subscription')->select(
+    'reason',
+     where => {'user' => $user_row_id, 'issue' => $issue}
+   )->value;
+
+  my %reasons = (
+    'S' => 'subscribed',
+    'O' => 'own the repository',
+    'N' => 'authored the thread',
+    'C' => 'commented',
+    'M' => 'were mentioned',
+    'W' => 'watch the repository'
+  );
+
+  my $reason_text;
+  my $subscribed = 0;
+
+  if (!defined $reason) {
+    $reason_text = "didn't subscribed";
+  }
+  elsif ($reason eq 'U') {
+    $reason_text = 'unsubscribed';
+  }
+  else {
+    $subscribed = 1;
+    $reason_text = $reasons{$reason};
+  }
+%>
+
+<button id="subscribe-btn" class="subscription-btn">
+  <svg class="subscription-btn-icon" aria-hidden="true" viewBox="0 0 16 16" height="16" width="16">
+    % if (!$subscribed) {
+      <path d="M8 16a2 2 0 0 0 1.985-1.75c.017-.137-.097-.25-.235-.25h-3.5c-.138 0-.252.113-.235.25A2 2 0 0 0 8 16ZM3 5a5 5 0 0 1 10 0v2.947c0 .05.015.098.042.139l1.703 2.555A1.519 1.519 0 0 1 13.482 13H2.518a1.516 1.516 0 0 1-1.263-2.36l1.703-2.554A.255.255 0 0 0 3 7.947Zm5-3.5A3.5 3.5 0 0 0 4.5 5v2.947c0 .346-.102.683-.294.97l-1.703 2.556a.017.017 0 0 0-.003.01l.001.006c0 .002.002.004.004.006l.006.004.007.001h10.964l.007-.001.006-.004.004-.006.001-.007a.017.017 0 0 0-.003-.01l-1.703-2.554a1.745 1.745 0 0 1-.294-.97V5A3.5 3.5 0 0 0 8 1.5Z"></path>  
+  % } else {
+    <path d="m4.182 4.31.016.011 10.104 7.316.013.01 1.375.996a.75.75 0 1 1-.88 1.214L13.626 13H2.518a1.516 1.516 0 0 1-1.263-2.36l1.703-2.554A.255.255 0 0 0 3 7.947V5.305L.31 3.357a.75.75 0 1 1 .88-1.214Zm7.373 7.19L4.5 6.391v1.556c0 .346-.102.683-.294.97l-1.703 2.556a.017.017 0 0 0-.003.01c0 .005.002.009.005.012l.006.004.007.001ZM8 1.5c-.997 0-1.895.416-2.534 1.086A.75.75 0 1 1 4.38 1.55 5 5 0 0 1 13 5v2.373a.75.75 0 0 1-1.5 0V5A3.5 3.5 0 0 0 8 1.5ZM8 16a2 2 0 0 1-1.985-1.75c-.017-.137.097-.25.235-.25h3.5c.138 0 .252.113.235.25A2 2 0 0 1 8 16Z"></path>
+  % }
+  </svg>
+  <span class="subscription-btn-text">
+    <%= $subscribed? 'Unsubscribe': 'Subscribe'%>
+  </span>
+</button>
+<div class="notif-reason">
+  <span>You’re <%= $subscribed? '': 'not ' %>receiving notifications
+    % if (defined $reason_text) {
+      because you <%= $reason_text %>
+    % }
+  </span>.
+  % if (!$api->app->{mailtransport}) {
+    <p style="margin-top: 3px;">Notifications are currently disabled.</p>
+  % }
+</div>
+<script type="text/javascript">
+$('#subscribe-btn').on('click', function() {
+  $.ajax({
+    type: 'GET',
+    url: '<%= url_for("/$user/$project/api/subscribe/$issue/" . ($subscribed? "U": "S")) %>',
+    dataType: 'html',
+    error: function(jqXHR, textStatus, errorThrown) { 
+      alert(textStatus);
+    },
+    success: function(html) {
+      $('#subscription-frame').html(html);
+    }
+  });
+});
+</script>

--- a/templates/issue.html.ep
+++ b/templates/issue.html.ep
@@ -58,8 +58,20 @@
       
       if ($validation->is_valid) {
 
-        $api->add_issue_message($user_id, $project_id, $number, $message);
-        
+        my $msgno =$api->add_issue_message($user_id, $project_id,
+                                           $number, $message);
+
+        # Subscriptions.
+        $api->subscribe($api->session_user_row_id, $issue_row_id, 'C');
+        $api->subscribe_mentioned($issue_row_id, $message);
+
+        # Notifications.
+        $api->notify_subscribed($user_id, $project_id,
+                                "$issue->{title} (#$number)",
+                                $api->session_user_row_id, $message,
+                                "comment-$msgno", "issues/$number",
+                                $issue_row_id);
+
         $self->redirect_to;
         return;
       }
@@ -324,6 +336,11 @@
           </li>
         % }
       </ul>
+      % if ($api->logined) {
+        <div id="subscription-frame" class="issue-subscription">
+          <%== $self->render_to_string(template => '/api/subscribe', 'issue' => $issue_row_id, 'reason' => undef) %>
+        </div>
+      % }
     </div>
   </div>
 </div>

--- a/templates/issues/new.html.ep
+++ b/templates/issues/new.html.ep
@@ -88,8 +88,21 @@
           };
           
           app->dbi->model('issue_message')->insert($new_issue_message);
+
+          # Subscriptions.
+          $api->subscribe($api->get_user_row_id($user_id),
+                          $new_issue_row_id, 'O');
+          $api->subscribe($session_user_row_id, $new_issue_row_id, 'N');
+          $api->subscribe_mentioned($new_issue_row_id, $message);
+
+          # Notifications.
+          $api->notify_subscribed($user_id, $project_id,
+                                  "$title (#$issue_number)",
+                                  $session_user_row_id, $message,
+                                  "comment-1", "issues/$issue_number",
+                                  $new_issue_row_id);
         });
-        
+
         $self->redirect_to("/$user_id/$project_id/issues/$issue_number");
         return;
       }


### PR DESCRIPTION
Users can be subscribed to an issue by creating the issue, commenting, being mentioned or owning the repository. At any time they can explicitly subscribe/unsubscribe via a button on the issue page.

Notifications can be sent either by SMTP or the external sendmail program. Note that esmtp's sendmail is not suitable for that use.

E-mails have both plain text and HTML alternative contents.
New external modules are used (see README.md). I did not use Mojolicious::Plugin::Mail because it is based on MIME::Lite which is not recommended by its maintainer.

PR handling is not (yet) ready for notifications. Likewise, it is not possible to comment an issue by replying to a notification mail.

This could probably be written in a more perlish/elegant way as I'm more targetted on C and Python. However it works.

Thanks for your thorough review,
Patrick