### PR TITLE
Defer time locale and timezone handling to browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,13 +361,8 @@ Please fix it the following way.
 
 ### I want to set time zone.
 
-OK. GitPrep supports time zones. You can set time_zone option in conig file.
-
-    [basic]
-    ;;; Time Zone
-    ;;; GitPrep time zone is GMT by default
-    ;;; You can set your local time zone.
-    time_zone=+9:00
+Gitprep is timezone-agnostic. It delegates time zone handling to the browser.
+If you want to change the time zone, do it on your client system.
 
 ### How to hide user home directory in ssh repository URL?
 

--- a/gitprep.conf.example
+++ b/gitprep.conf.example
@@ -23,13 +23,6 @@
 ;;; Tags limit (default:1000)
 ; tags_limit=1000
 
-;;; Time Zone
-;;; GitPrep time zone is GMT by default
-;;; You can set your local time zone.
-; time_zone=+9:00
-; time_zone=+10:30
-; time_zone=-4:00
-
 ;;; authorized_keys file for public key authentication via ssh.
 ;;; default is "$ENV{HOME}/.ssh/authorized_keys"
 ; authorized_keys_file=/home/gitprep/.ssh/authorized_keys

--- a/lib/Gitprep.pm
+++ b/lib/Gitprep.pm
@@ -189,22 +189,7 @@ sub startup {
     mkdir $rep_home
       or croak "Can't create directory $rep_home: $!";
   }
-  
-  # Time Zone
-  if (my $time_zone = $conf->{basic}{time_zone}) {
-    
-    if ($time_zone =~ /^([\+-])?([0-9]?[0-9]):([0-9][0-9])$/) {
-      my $sign = $1 || '';
-      my $hour = $2;
-      my $min = $3;
-      
-      my $time_zone_second = $sign . ($hour * 60 * 60) + ($min * 60);
-      $git->time_zone_second($time_zone_second);
-    }
-    else {
-      $self->log->warn("Bad time zone $time_zone. Time zone become GMT");
-    }
-  }
+
   $self->git($git);
   
   # DBI

--- a/public/js/gitprep.js
+++ b/public/js/gitprep.js
@@ -1,0 +1,42 @@
+// Gitprep namesspace.
+(function(Gitprep, $, undefined) {
+  var dateFmt = new Intl.DateTimeFormat(undefined, {    // Tooltips date format.
+    dateStyle: 'medium',
+    timeStyle: 'long',
+  });
+  var dayFmt = new Intl.DateTimeFormat(undefined, {    // Commits day format.
+    dateStyle: 'medium',
+  });
+
+  // Set element tooltip from a Unix timestamp using browser locale and
+  // timezone.
+  Gitprep.dateTooltip = function (elem, ts) {
+    elem.setAttribute('title', dateFmt.format(new Date(ts * 1000)));
+    elem.removeAttribute('onmouseover');
+  };
+
+  // Split unnumbered list of commits into several lists, one for each day
+  // with a day header prepended, taking the browser timezone into account.
+  // Each list item holds its Unix timestamp in a "ts" attribute.
+  Gitprep.commitsByDay = function (ul) {
+    var container = $(ul);
+    var lastDay;
+    var dayUl;
+
+    $('li[ts]', container).each(function () {
+      var day = dayFmt.format(new Date($(this).attr('ts') * 1000));
+      if (day != lastDay) {
+        var dayHeader = $('<div class="commit-date"><i class="icon-off"></i></div>');
+        var dayLabel = $('<span></span>');
+        dayLabel.text('Commits on ' + day);
+        dayHeader.append(dayLabel);
+        container.before(dayHeader);
+        dayUl = $(container.get(0).cloneNode(false));
+        container.before(dayUl);
+        lastDay = day;
+      }
+      dayUl.append($(this));
+    });
+    container.remove();
+  };
+}(window.Gitprep = window.Gitprep || {}, jQuery));

--- a/t/age_string.t
+++ b/t/age_string.t
@@ -4,7 +4,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use lib "$FindBin::Bin/../extlib/lib/perl5";
 
-use Gitprep::Git;
+use Gitprep::API;
 
 my @cases = (
   { stimulus =>                           0,     expected => 'right now'     },
@@ -37,5 +37,5 @@ my @cases = (
 );
 
 for ( @cases ) {
-  is ( Gitprep::Git->new->_age_string ( $_->{stimulus} ), $_->{expected}, "$_->{stimulus} sec ~ \"$_->{expected}\"" );
+  is ( Gitprep::API->new->_age_string ( $_->{stimulus} ), $_->{expected}, "$_->{stimulus} sec ~ \"$_->{expected}\"" );
 }

--- a/templates/auto/_search.html.ep
+++ b/templates/auto/_search.html.ep
@@ -129,7 +129,7 @@
                   </div>
                   <div class="text-gray" style="font-size:13px;">
                     % if ($commit) {
-                      <span title="<%= $commit->{age_string_datetime_local} %>"><%= $commit->{age_string} %>
+                     %= $api->age_element($commit->{committer_epoch});
                     % } else {
                       <span >Repositry is not yet created.
                     % }

--- a/templates/blame.html.ep
+++ b/templates/blame.html.ep
@@ -125,8 +125,8 @@
                 </div>
                 <div class="blame-author">
                   <span title="<%= $line->{author_email} %>"><%= $line->{author} %></span>
-                  authored on
-                  <%= $line->{author_age_string_date_local} %>
+                  authored
+                  %= $api->age_element($line->{author_time});
                 </div>
               </td>
             % }

--- a/templates/blob.html.ep
+++ b/templates/blob.html.ep
@@ -78,7 +78,7 @@
         <a href="<%= url_for("$user_id_project_path/commit/$commit->{id}") %>">
           <%= substr($commit->{id}, 0, 7) %>
         </a>
-        <span title="<%= $commit->{age_string_datetime_local} %>"><%= $commit->{age_string} %></span>
+        %= $api->age_element($commit->{committer_epoch});
       </div>
     </div>
           

--- a/templates/branches.html.ep
+++ b/templates/branches.html.ep
@@ -165,10 +165,12 @@
                         <%= $branch_name %>
                       </a>
                     </div>
-                    <div class="branches-age" title="<%= $branch->{commit}{age_string_datetime_local} %>">
-                      Updated <%= $branch->{commit}{age_string} %> by
+                    <div class="branches-age">
+                      Updated
+                      %= $api->age_element($branch->{commit}{committer_epoch});
                     </div>
                     <div class="branches-author"  title="<%= $branch->{commit}{author_email} %>">
+                      by
                       % if (defined $commit_author_id) {
                         <a href="<%= url_for("/$commit_author_id") %>"><%= $commit_author_id %></a>
                       % } else {

--- a/templates/commit.html.ep
+++ b/templates/commit.html.ep
@@ -26,12 +26,6 @@
     $self->reply->not_found;
     return;
   }
-  my $author_date
-    = $git->parse_date($commit->{author_epoch}, $commit->{author_tz});
-  my $committer_date
-    = $git->parse_date($commit->{committer_epoch}, $commit->{committer_tz});
-  $commit->{author_date} = $git->timestamp($author_date);
-  $commit->{committer_date} = $git->timestamp($committer_date);
   $from_rev = $commit->{parent} unless defined $from_rev;
   my $commit_short_id = substr($commit->{id}, 0, 7, );
   my $commit_author_email = $commit->{author_email};
@@ -126,7 +120,8 @@
               <%= $commit->{author_name} %>
             % }
           </span>
-          <span>commited on <span title="<%= $commit->{age_string_datetime_local} %>"><%= $commit->{age_string_date_local} %></span>
+          commited
+          %= $api->age_element($commit->{committer_epoch});
         </li>
         <li class="last-child">
           % my $parents = $commit->{parents};

--- a/templates/commits.html.ep
+++ b/templates/commits.html.ep
@@ -41,42 +41,31 @@
     $file
   );
   my $commits_count = @$commits;
-  my $commits_date = {};
-  for my $commit (@$commits) {
-    my $date = $commit->{age_string_date_local};
-    $commits_date->{$date} ||= [];
-    push @{$commits_date->{$date}}, $commit;
-  }
-  
+
   # Global variable
   stash(user => $user_id, project => $project_id, rev => $rev);
-  
+
   # Render atom xml feed
   if ($render_atom_feed) {
     # Add updated date time
     for my $commit (@$commits) {
       my $committer_epoch = $commit->{committer_epoch};
       my $committer_tz = $commit->{committer_tz};
-      
-      my $time_zone_second;
-      my $time_zone;
+
+      my $time_zone_minutes = 0;
       if ($committer_tz =~ /^(\+|\-)([0-9]{2})([0-9]{2})$/) {
         my $time_zone_sign = $1;
         my $time_zone_hour = $2;
         my $time_zone_min = $3;
-        $time_zone_second = $time_zone_sign . ($time_zone_hour * (60 * 60) + $time_zone_min * 60);
-        $time_zone = sprintf("$time_zone_sign%02d:%02d", $time_zone_hour, $time_zone_min);
+        $time_zone_minutes = $time_zone_sign . ($time_zone_hour * 60 + $time_zone_min);
       }
 
       # updated datetime
-      my ($sec, $min, $hour, $mday, $mon, $year, $wday, $yday) = gmtime($committer_epoch + $time_zone_second);
-      my $updated = sprintf('%4d-%02d-%02dT%02d:%02d:%02d', 1900 + $year, $mon + 1, $mday, $hour, $min, $sec);
-      $updated .= $time_zone;
-      
-      $commit->{updated} = $updated;
+      $commit->{updated} = $api->strftime($committer_epoch, '%FT%T%Z',
+        $time_zone_minutes);
     }
   }
-  
+
   # Set stash
   stash(
     user => $user_id,
@@ -101,6 +90,9 @@
   <updated><%= $commits->[0]->{updated} %></updated>
 
     % for my $commit (@$commits) {
+      <%
+        my $author_id = app->dbi->model('user')->select('id', where => {email => $commit->{author_email}})->value;
+      %>
   <entry>
     <id>tag:gitprep,2008:Grit::Commit/<%= $commit->{id} %></id>
     <link type="text/html" rel="alternate" href="<%= url_for("$user_project_path/commit/$commit->{id}")->to_abs %>" />
@@ -109,8 +101,13 @@
     </title>
     <updated><%= $commit->{updated} %></updated>
     <author>
-      <name><%= $user_id %></name>
-      <uri><%= url_for("/$user_id")->to_abs %></uri>
+      % if ($author_id) {
+        <name><%= $author_id %></name>
+        <uri><%= url_for("/$author_id")->to_abs %></uri>
+      % }
+      % else {
+        <name><%= $commit->{author_name} %></name>
+      % }
     </author>
     <content type="html">
       <%= "<pre style='white-space:pre-wrap;width:81ex'>$commit->{title}</pre>" %>
@@ -131,56 +128,66 @@
       % }
       
       <div class="commits">
-        % for my $date (reverse sort keys %$commits_date) {
-          % my $commits = $commits_date->{$date};
-          <div class="commit-date">
-            <i class="icon-off"></i><span>Commits on <%= $date %></span>
-          </div>
+        <ul class="commits-date-container">
+          % for my $commit (@$commits) {
+            <%
+              my $author_id = app->dbi->model('user')->select('id', where => {email => $commit->{author_email}})->value;
+            %>
+            <li ts="<%= $commit->{committer_epoch} %>">
+              <div class="commit-left">
+                <div class="commit-left-title">
+                  <a href="<%= url_for("$user_project_path/commit/$commit->{id}") %>">
+                    <b><%= $commit->{title_short} %></b>
+                  </a>
+                </div>
+                <div class="commit-left-author">
+                  <span title="<%= $commit->{author_email} %>">
 
-          <ul class="commits-date-container">
-            % my $num = 0;
-            % for my $commit (sort {$b->{author_epoch} <=> $a->{author_epoch}} @$commits) {
-              <%
-                my $author_id = app->dbi->model('user')->select('id', where => {email => $commit->{author_email}})->value;              %>
-              <li>
-                <div class="commit-left">
-                  <div class="commit-left-title">
-                    <a href="<%= url_for("$user_project_path/commit/$commit->{id}") %>">
-                      <b><%= $commit->{title_short} %></b>
-                    </a>
-                  </div>
-                  <div class="commit-left-author">
-                    <span title="<%= $commit->{author_email} %>">
-                    
-                      % if (defined $author_id) {
-                        <a href="<%= url_for("/$author_id") %>"><%= $author_id %></a>
+                    % if (defined $author_id) {
+                      <a href="<%= url_for("/$author_id") %>"><%= $author_id %></a>
+                    % } else {
+                      <%= $commit->{author_name} %>
+                    % }
+                  </span>
+                  % if ($commit->{author_email} ne $commit->{committer_email}) {
+                    <%
+                      my $committer_id = app->dbi->model('user')->select('id', where => {email => $commit->{committer_email}})->value;
+                    %>
+                    authored and
+                    <span title="<%= $commit->{committer_email} %>">
+
+                      % if (defined $committer_id) {
+                        <a href="<%= url_for("/$committer_id") %>"><%= $committer_id %></a>
                       % } else {
-                        <%= $commit->{author_name} %>
+                        <%= $commit->{committer_name} %>
                       % }
                     </span>
-                    <span class="muted" title="<%= $commit->{age_string_datetime_local} %>"><%= $commit->{age_string} %></span>
+                  % }
+                  committed
+                  %= $api->age_element($commit->{committer_epoch}, class => 'muted');
+                </div>
+              </div>
+              <div class="commit-right">
+                <div class="commit-right-container">
+                  <div class="commit-right-commit-id">
+                    <a href="<%= url_for("$user_project_path/commit/$commit->{id}") %>">
+                      <%= substr($commit->{id}, 0, 7) %>
+                    </a>
+                  </div>
+                  <div class="commit-right-browse-repository">
+                    <a title="Browse the repository at this point in the history" href="<%= url_for("$user_project_path/commit/$commit->{id}") %>">
+                      &lt;&gt;
+                    </a>
                   </div>
                 </div>
-                <div class="commit-right">
-                  <div class="commit-right-container">
-                    <div class="commit-right-commit-id">
-                      <a href="<%= url_for("$user_project_path/commit/$commit->{id}") %>">
-                        <%= substr($commit->{id}, 0, 7) %>
-                      </a>
-                    </div>
-                    <div class="commit-right-browse-repository">
-                      <a title="Browse the repository at this point in the history" href="<%= url_for("$user_project_path/commit/$commit->{id}") %>">
-                        &lt;&gt;
-                      </a>
-                    </div>
-                  </div>
-                </div>
-                % $num++;
-              </li>
-            % }
-          </ul>
-        % }
+              </div>
+            </li>
+          % }
+        </ul>
       </div>
+      %= javascript begin
+        Gitprep.commitsByDay($('.commits-date-container'));
+      % end
 
       %= include '/include/pagination', page => $page, rows_per_page => $page_count, query => {}, left => 'Newer', right => 'Older';
     </div>

--- a/templates/compare.html.ep
+++ b/templates/compare.html.ep
@@ -110,8 +110,7 @@
           return;
         }
         else {
-          my $now_tm = Time::Moment->now_utc;
-          my $now_epoch = $now_tm->epoch;
+          my $now_epoch = $api->now;
           my $session_user_row_id = $api->session_user_row_id;
           my $issue_number;
           app->dbi->connector->txn(sub {
@@ -218,13 +217,9 @@
   );
 
   my $commits_count = @$commits;
-  my $commits_date = {};
   my $authors = {};
   for my $commit (@$commits) {
-    my $date = $commit->{age_string_date_local};
-    $commits_date->{$date} ||= [];
     $authors->{$commit->{author}} = 1;
-    push @{$commits_date->{$date}}, $commit;
   }
   my $authors_count = keys %$authors;
 
@@ -245,15 +240,15 @@
   
   # Base branches
   my $base_branches = $git->branches($base_rep_info);
-  @$base_branches = sort { $a->{commit}{age} <=> $b->{commit}{age} } @$base_branches;
+  @$base_branches = sort { $b->{commit}{committer_epoch} <=> $a->{commit}{committer_epoch} } @$base_branches;
 
   # Target branches
   my $target_branches = $git->branches($target_rep_info);
-  @$target_branches = sort { $a->{commit}{age} <=> $b->{commit}{age} } @$target_branches;
+  @$target_branches = sort { $b->{commit}{committer_epoch} <=> $a->{commit}{committer_epoch} } @$target_branches;
   
   # Can open pull request
   my $can_open_pull_request;
-  if (keys %$commits_date && $expand) {
+  if (@$commits && $expand) {
     $can_open_pull_request = 1;
   }
   
@@ -599,7 +594,7 @@
         Pull request #<%= $issue->{number} %>
       </a>
     </div>
-  % } elsif (keys %$commits_date && $merge_success) {
+  % } elsif (@$commits && $merge_success) {
     <div class="issue-add-comment" style="width:80%">
       <form action="<%= url_for %>" method="post">
         <%= hidden_field op => 'create-pull-request' %>
@@ -630,7 +625,7 @@
     </div>
   % }
 
-  % if (keys %$commits_date) {
+  % if (@$commits) {
     <ul class="compare-header">
       <li>
         <b><%= @$commits %></b> <span>commit</span>
@@ -647,47 +642,43 @@
     </ul>
     
     <div class="commits">
-      % for my $date (reverse sort keys %$commits_date) {
-        % my $commits = $commits_date->{$date};
-        
-        <div class="commit-date">
-          <i class="icon-off"></i><span>Commits on <%= $date %></span>
-        </div>
-        
-        <ul class="compare-commits-date-container">
-          % for my $commit (sort {$b->{author_epoch} <=> $a->{author_epoch}} @$commits) {
-            <%
-              my $commit_author_email = $commit->{author_email};
-              my $commit_author_id = app->dbi->model('user')->select(
-                'id',
-                where => {email => $commit_author_email}
-              )->value;
-            %>
-            <li>
-              <div class="compare-commits-author">
-                <span title="<%= $commit->{author_email} %>">
-                  % if (defined $commit_author_id) {
-                    <a href="<%= url_for("/$commit_author_id") %>"><%= $commit_author_id %></a>
-                  % } else {
-                    <%= $commit->{author_name} %>
-                  % }
-                </span>
-              </div>
-              <div class="compare-commits-commit-title">
-                <a style="color:#333" href="<%= url_for("/$target_user_id/$target_project->{id}/commit/$commit->{id}") %>">
-                  <%= $commit->{title_short} %>
-                </a>
-              </div>
-              <div class="compare-commits-commit-id">
-                <a href="<%= url_for("/$target_user_id/$target_project->{id}/commit/$commit->{id}") %>">
-                  <%= substr($commit->{id}, 0, 7) %>
-                </a>
-              </div>
-            </li>
-          % }
-        </ul>
-      % }
+      <ul class="compare-commits-date-container">
+        % for my $commit (@$commits) {
+          <%
+            my $commit_author_email = $commit->{author_email};
+            my $commit_author_id = app->dbi->model('user')->select(
+              'id',
+              where => {email => $commit_author_email}
+            )->value;
+          %>
+          <li ts="<%= $commit->{committer_epoch} %>">
+            <div class="compare-commits-author">
+              <span title="<%= $commit->{author_email} %>">
+                % if (defined $commit_author_id) {
+                  <a href="<%= url_for("/$commit_author_id") %>"><%= $commit_author_id %></a>
+                % } else {
+                  <%= $commit->{author_name} %>
+                % }
+              </span>
+            </div>
+            <div class="compare-commits-commit-title">
+              <a style="color:#333" href="<%= url_for("/$target_user_id/$target_project->{id}/commit/$commit->{id}") %>">
+                <%= $commit->{title_short} %>
+              </a>
+            </div>
+            <div class="compare-commits-commit-id">
+              <a href="<%= url_for("/$target_user_id/$target_project->{id}/commit/$commit->{id}") %>">
+                <%= substr($commit->{id}, 0, 7) %>
+              </a>
+            </div>
+          </li>
+        % }
+      </ul>
     </div>
+
+    %= javascript begin
+      Gitprep.commitsByDay($('.compare-commits-date-container'));
+    % end
   
     %= include '/include/commit_body', %commit_body_args;
   % } else {

--- a/templates/include/issue_message.html.ep
+++ b/templates/include/issue_message.html.ep
@@ -16,7 +16,10 @@
   <div id="comment-<%= $issue_message->{number} %>" class="issue-message <%= $is_owner_comment ? 'issue-message-owner' : '' %>" tabindex="-1">
     <div class="issue-message-header <%= $is_owner_comment ? 'issue-message-header-owner' : '' %>">
       <div class="issue-message-header-left">
-        <b><%= $issue_message->{'user.id'} %></b> <span style="color:#767676;">commented <%= $api->age_string($issue_message->{update_time}) %></span>
+        <b><%= $issue_message->{'user.id'} %></b>
+        <span style="color:#767676;">commented
+          %= $api->age_element($issue_message->{update_time});
+        </span>
       </div>
       <div class="issue-message-header-right">
         % if ($is_owner_comment) {

--- a/templates/include/tree.html.ep
+++ b/templates/include/tree.html.ep
@@ -1,4 +1,7 @@
 <%
+  # API
+  my $api = gitprep_api;
+
   my $dir = stash('dir');
   my $commit_author_email = $commit->{author_email};
   my $commit_author_id = app->dbi->model('user')->select(
@@ -26,7 +29,7 @@
       <a href="<%= url_for("/$user/$project/commit/$commit->{id}") %>">
         <%= substr($commit->{id}, 0, 7) %>
       </a>
-      <%= $commit->{age_string} %>
+      %= $api->age_element($commit->{committer_epoch});
     </div>
   </div>
   <ul class="file-list">
@@ -68,7 +71,7 @@
           </a>
         </div>
         <div class="file-list-age">
-          <span title="<%= $commit->{age_string_datetime_local} %>"><%= $commit->{age_string} %></span>
+          %= $api->age_element($commit->{committer_epoch});
         </div>
       </li>
     % }

--- a/templates/issue.html.ep
+++ b/templates/issue.html.ep
@@ -19,7 +19,6 @@
   my $target_project_id;
   my $merge_success;
   my $commits;
-  my $commits_date = {};
   my $authors = {};
   my $tabs;
   my $http_rep_url;
@@ -107,7 +106,7 @@
         return;
       }
 
-      my $open_time = time;
+      my $open_time = $api->now;
       app->dbi->model('issue')->update(
         {
           open => 1,
@@ -387,10 +386,7 @@
       $target_branch
     );
     for my $commit (@$commits) {
-      my $date = $commit->{age_string_date_local};
-      $commits_date->{$date} ||= [];
       $authors->{$commit->{author}} = $commit;
-      push @{$commits_date->{$date}}, $commit;
     }
 
     # Start commit
@@ -589,7 +585,9 @@
               <%= $pull_request->{target_branch} %>
             </span>
           % } else {
-            opened this issue <%= $api->age_string($issue->{open_time}) %> / <%= scalar @$issue_messages %> comment
+            opened this issue
+            %= $api->age_element($issue->{open_time});
+            / <%= scalar @$issue_messages %> comment
           % }
         </span>
       </div>
@@ -618,46 +616,41 @@
       % if ($activetab eq 'commits') {
 
         <div class="commits">
-          % for my $date (reverse sort keys %$commits_date) {
-            % my $commits = $commits_date->{$date};
-
-            <div class="commit-date">
-              <i class="icon-off"></i><span>Commits on <%= $date %></span>
-            </div>
-
-            <ul class="compare-commits-date-container">
-              % for my $commit (sort {$b->{author_epoch} <=> $a->{author_epoch}} @$commits) {
-                <%
-                  my $commit_author_email = $commit->{author_email};
-                  my $commit_author_id = app->dbi->model('user')->select(
-                    'id',
-                    where => {email => $commit_author_email}
-                  )->value;
-                %>
-                <li>
-                  <div class="compare-commits-author">
-                    <span title="<%= $commit->{author_email} %>">
-                      % if (defined $commit_author_id) {
-                        <a href="<%= url_for("/$commit_author_id") %>"><%= $commit_author_id %></a>
-                      % } else {
-                        <%= $commit->{author_name} %>
-                      % }
-                    </span>
-                  </div>
-                  <div class="compare-commits-commit-title">
-                    <a style="color:#333" href="<%= url_for("/$target_user_id/$target_project->{id}/commit/$commit->{id}") %>">
-                      <%= $commit->{title_short} %>
-                    </a>
-                  </div>
-                  <div class="compare-commits-commit-id">
-                    <a href="<%= url_for("/$target_user_id/$target_project->{id}/commit/$commit->{id}") %>">
-                      <%= substr($commit->{id}, 0, 7) %>
-                    </a>
-                  </div>
-                </li>
-              % }
-            </ul>
-          % }
+          <ul class="compare-commits-date-container">
+            % for my $commit (@$commits) {
+              <%
+                my $commit_author_email = $commit->{author_email};
+                my $commit_author_id = app->dbi->model('user')->select(
+                  'id',
+                  where => {email => $commit_author_email}
+                )->value;
+              %>
+              <li ts="<%= $commit->{committer_epoch} %>">
+                <div class="compare-commits-author">
+                  <span title="<%= $commit->{author_email} %>">
+                    % if (defined $commit_author_id) {
+                      <a href="<%= url_for("/$commit_author_id") %>"><%= $commit_author_id %></a>
+                    % } else {
+                      <%= $commit->{author_name} %>
+                    % }
+                  </span>
+                </div>
+                <div class="compare-commits-commit-title">
+                  <a style="color:#333" href="<%= url_for("/$target_user_id/$target_project->{id}/commit/$commit->{id}") %>">
+                    <%= $commit->{title_short} %>
+                  </a>
+                </div>
+                <div class="compare-commits-commit-id">
+                  <a href="<%= url_for("/$target_user_id/$target_project->{id}/commit/$commit->{id}") %>">
+                    <%= substr($commit->{id}, 0, 7) %>
+                  </a>
+                </div>
+              </li>
+            % }
+          </ul>
+          %= javascript begin
+            Gitprep.commitsByDay($('.compare-commits-date-container'));
+          % end
         </div>
 
       % } elsif ($activetab eq 'files') {

--- a/templates/issues.html.ep
+++ b/templates/issues.html.ep
@@ -136,8 +136,6 @@
               <%
                 my $kind = $issue->{pull_request}? 'pull': 'issues';
                 my $open_time = $issue->{open_time};
-                my $open_time_age = Time::Moment->now->epoch - $open_time;
-                my $open_time_age_string = $self->app->git->_age_string($open_time_age);
                 my $issue_labels = app->dbi->model('issue_label')->select(
                   {label => ['id', 'color']},
                   where => {issue => $issue->{row_id}}
@@ -165,7 +163,7 @@
                     </div>
                     <div class="issues-description">
                       #<%= $issue->{number} %> <%= $issue->{open} ? 'opened' : 'closed' %>
-                      <%= $open_time_age_string %>
+                      %= $api->age_element($issue->{open_time});
                       by <%= $issue->{'open_user.id'} %>
                     </div>
                  </div>

--- a/templates/issues/new.html.ep
+++ b/templates/issues/new.html.ep
@@ -49,8 +49,7 @@
         )->value;
         
         my $issue;
-        my $now_tm = Time::Moment->now_utc;
-        my $now_epoch = $now_tm->epoch;
+        my $now_epoch = $api->now;
         my $session_user_row_id = $api->session_user_row_id;
         my $issue_number;
         

--- a/templates/layouts/common.html.ep
+++ b/templates/layouts/common.html.ep
@@ -23,6 +23,7 @@
     % }
     %= javascript '/js/jquery-1.9.0.min.js';
     %= javascript '/js/bootstrap.min.js';
+    %= javascript '/js/gitprep.js';
     
     <link rel="shortcut icon" href="<%= url_for('/git-favicon.png') %>" type="image/png" />
     % if (length $user && length $project && length $rev) {

--- a/templates/network/graph.html.ep
+++ b/templates/network/graph.html.ep
@@ -1,4 +1,8 @@
 <%
+  # API
+  my $api = gitprep_api;
+
+  # Parameters
   my $user = param('user');
   my $project = param('project');
   my $branch = param('rev1');
@@ -16,8 +20,7 @@
   for my $commit (@$commits) {
     my $id = $commit->{id};
     $merged_commits_h->{$id} ||= {};
-    $merged_commits_h->{$id}{age} = $commit->{age};
-    $merged_commits_h->{$id}{age_string_date_local} = $commit->{age_string_date_local};
+    $merged_commits_h->{$id}{epoch} = $commit->{committer_epoch};
     $merged_commits_h->{$id}{title} = $commit->{title};
     $merged_commits_h->{$id}{type} = 'local';
   }
@@ -28,8 +31,7 @@
     }
     else {
       $merged_commits_h->{$id} ||= {};
-      $merged_commits_h->{$id}{age} = $commit->{age};
-      $merged_commits_h->{$id}{age_string_date_local} = $commit->{age_string_date_local};
+      $merged_commits_h->{$id}{epoch} = $commit->{committer_epoch};
       $merged_commits_h->{$id}{title} = $commit->{title};
       $merged_commits_h->{$id}{type} = 'remote';
     }
@@ -37,7 +39,7 @@
   
   my $merged_commits = [];
   for my $id (
-    sort { $merged_commits_h->{$b}{age} <=> $merged_commits_h->{$a}{age}}
+    sort { $merged_commits_h->{$a}{epoch} <=> $merged_commits_h->{$b}{epoch}}
     keys %$merged_commits_h)
   {
     my $commit = {%{$merged_commits_h->{$id}}};
@@ -76,7 +78,8 @@
 
               % if ($commit->{type} eq $type) {
                 <td>
-                  <a style="color:<%= $color %>" href="<%= url_for("/$user/$project/commit/$commit->{id}") %>" title="<%= "$commit->{title}($commit->{age_string_date_local})" %>">●</a>
+                  % my $utcday = $api->strftime($commit->{epoch}, '%F');
+                  <a style="color:<%= $color %>" href="<%= url_for("/$user/$project/commit/$commit->{id}") %>" title="<%= "$commit->{title} ($utcday)" %>">●</a>
                 </td>
               % } else {
                 <td></td>

--- a/templates/tags.html.ep
+++ b/templates/tags.html.ep
@@ -39,7 +39,7 @@
           <li>
             <ul class="tags-item">
               <li>
-                <span title="<%= $tag->{commit}{age_string_datetime_local} %>">on <%= $tag->{commit}{age_string_date_local} %></span>
+                %= $api->age_element($tag->{commit}{committer_epoch});
               </li>
               <li class="last-child">
                 <div class="tags-name">

--- a/templates/user.html.ep
+++ b/templates/user.html.ep
@@ -25,7 +25,6 @@
     my $rep = app->git->repository(app->rep_info($user_id, $project->{id})) || {none => 1};
     $rep->{id} = $project->{id};
     $rep->{private} = $project->{private};
-    $rep->{age} //= 0;
     push @$reps, $rep;
   }
 %>
@@ -41,7 +40,7 @@
         <div class="topic1">Repositories</div>
         
         <ul class="repositories">
-          % for my $rep (sort { $a->{age} <=> $b->{age} } @$reps) {
+          % for my $rep (sort { ($b->{timestamp} || 0) <=> ($a->{timestamp} || 0) } @$reps) {
             % if (!$rep->{private} || $api->can_access_private_project($user_id, $rep->{id})) {
               <li>
                 % my $project_id = $rep->{id};
@@ -57,12 +56,14 @@
                   <%= $rep->{description} %>
                 </div>
                 <div class="repositories-age">
-                  % my $age = $rep->{age_string};
                   % if ($rep->{none}) {
-                    <span style="color:red">Repository not exists</span>
+                    <span style="color:red">Repository does not exist</span>
                     <a href="<%= "/$user_id/$rep->{id}/settings" %>" class="btn btn-mini">Settings</a>
+                  % } elsif ($rep->{timestamp}) {
+                    last updated
+                    %= $api->age_element($rep->{timestamp});
                   % } else {
-                    <%= $age ? "last updated $age" : 'new repository' %>
+                    new repository
                   % }
                 </div>
               </li>


### PR DESCRIPTION
- Drop all absolute time strings in server and only keep Unix timestamps.
- Migrate time-related subroutines from Git module to API.
- Always get the current time via Time::Moment from a single new API subroutine: epoch is always the Unix epoch.
- Introduce an age HTML element featuring a dynamic localized absolute time tooltip and generalize its use.
- Split commit lists by day in browser, respecting the local timezone.
- The configuration file time_zone parameter is no longer used.
- Introduce a Javascript "Gitprep" namespace in a separate .js file.

Absolute timestamp tooltips are preset to an UTC standard string by the server in case the browser Javascript processing fails.

Commits atom feed still list commits timestamps within the original committer's timezone.

Compare graphs are not processed by the browser and always based on UTC.

Closes #214