### PR TITLE
Merge remotes

### DIFF
--- a/lib/Gitprep/Git.pm
+++ b/lib/Gitprep/Git.pm
@@ -729,7 +729,7 @@ sub forward_commits {
     $work_rep_info,
     'rev-list',
     '--left-right',
-    "$base_branch...$target_object_id"
+    "origin/$base_branch...$target_object_id"
   );
   open my $fh, '-|', @cmd
     or croak "Can't get info: @cmd";

--- a/lib/Gitprep/Manager.pm
+++ b/lib/Gitprep/Manager.pm
@@ -166,6 +166,22 @@ sub get_patch {
   return $patch;
 }
 
+sub merge_base {
+  my ($self, $work_rep_info, $base_branch, $target_rep_info, $target_branch) = @_;
+
+  my $target_remote = $target_rep_info->{user} . '/' . $target_rep_info->{project};
+  my @git_merge_base_cmd = $self->app->git->cmd(
+    $work_rep_info,
+    'merge-base',
+    "$target_remote/$target_branch",
+    "origin/$base_branch"
+  );
+  open my $fh, '-|', @git_merge_base_cmd or return;
+  my $merge_base = <$fh>;
+  chomp $merge_base;
+  return $merge_base;
+}
+
 sub push {
   my ($self, $work_rep_info, $base_branch) = @_;
   

--- a/lib/Gitprep/Manager.pm
+++ b/lib/Gitprep/Manager.pm
@@ -17,23 +17,54 @@ has 'authorized_keys_file';
 
 has '_tmp_branch' => '__gitprep_tmp_branch__';
 
+sub get_remotes {
+  my ($self, $rep_info) = @_;
+
+  my @git_remote_show_cmd = $self->app->git->cmd($rep_info, 'remote', '-v', 'show');
+  open my $fh, '-|', @git_remote_show_cmd
+    or croak "Execute git remote cmd:@git_remote_show_cmd";
+  my %remotes;
+  while (my $line = <$fh>) {
+    my ($remote, $url) = split /\s+/, $line;
+    $remotes{$remote} = $url;
+  }
+  return \%remotes;
+}
+
 sub prepare_merge {
   my ($self, $work_rep_info, $base_rep_info, $base_branch, $target_rep_info, $target_branch) = @_;
-  
+
+  my $git = $self->app->git;
+
   # Fetch base repository
   my $base_user_id = $base_rep_info->{user};
-  my @git_fetch_base_cmd = $self->app->git->cmd($work_rep_info, 'fetch', 'origin');
+  my @git_fetch_base_cmd = $git->cmd($work_rep_info, 'fetch', 'origin');
   Gitprep::Util::run_command(@git_fetch_base_cmd)
     or Carp::croak "Can't execute git fetch: @git_fetch_base_cmd";
-  
+
+  # Configure remote for target repository
+  my $target_remote = $target_rep_info->{user} . '/' . $target_rep_info->{project};
+  my $remotes = $self->get_remotes($work_rep_info);
+  if (exists $remotes->{$target_remote} && $remotes->{$target_remote} ne $base_rep_info->{root}) {
+    my @git_remote_remove_cmd = $git->cmd($work_rep_info, 'remote', 'remove', $target_remote);
+    Gitprep::Util::run_command(@git_remote_remove_cmd)
+      or Carp::croak "Can't execute git remote @git_remote_remove_cmd";
+    delete $remotes->{$target_remote};
+  }
+  if (!exists $remotes->{$target_remote}) {
+    my @git_remote_add_cmd = $git->cmd($work_rep_info, 'remote', 'add', $target_remote, $base_rep_info->{root});
+    Gitprep::Util::run_command(@git_remote_add_cmd)
+      or Carp::croak "Can't execute git remote @git_remote_add_cmd";
+  }
+
   # Fetch target repository
-  my @git_fetch_target_cmd = $self->app->git->cmd($work_rep_info, 'fetch', $target_rep_info->{git_dir});
-  
+  my @git_fetch_target_cmd = $git->cmd($work_rep_info, 'fetch', $target_remote);
+
   Gitprep::Util::run_command(@git_fetch_target_cmd)
     or Carp::croak "Can't execute git fetch: @git_fetch_target_cmd";
 
   # Ensure no diff
-  my @git_reset_hard_cmd = $self->app->git->cmd(
+  my @git_reset_hard_cmd = $git->cmd(
     $work_rep_info,
     'reset',
     '--hard'
@@ -61,7 +92,7 @@ sub prepare_merge {
   
   # Delete temporary branch if it exists
   if (grep { $_ eq $tmp_branch } @$branch_names) {
-    my @git_branch_remove_cmd = $self->app->git->cmd(
+    my @git_branch_remove_cmd = $git->cmd(
       $work_rep_info,
       'branch',
       '-D',
@@ -71,40 +102,23 @@ sub prepare_merge {
       or Carp::croak "Can't execute git branch: @git_branch_remove_cmd";
   }
 
-  # Create temporary branch
-  my @git_branch_cmd = $self->app->git->cmd(
-    $work_rep_info,
-    'branch',
-    $tmp_branch
-  );
-  Gitprep::Util::run_command(@git_branch_cmd)
-    or Carp::croak "Can't execute git branch: @git_branch_cmd";
-  
-  # Checkout tmp branch and git reset --hard from my remote branch
-  my @git_checkout_tmp_branch = $self->app->git->cmd(
+  # Create temporary branch from base branch and check it out
+  my @git_branch_cmd = $git->cmd(
     $work_rep_info,
     'checkout',
-    $tmp_branch
+    '-b',
+    $tmp_branch,
+    "origin/$base_branch"
   );
-  Gitprep::Util::run_command(@git_checkout_tmp_branch)
-    or Carp::croak "Can't execute git checkout: @git_checkout_tmp_branch";
-  
-  # git reset --hard 
-  my $base_object_id = $self->app->git->ref_to_object_id($base_rep_info, $base_branch);
-  my @git_reset_hard_base_cmd = $self->app->git->cmd(
-    $work_rep_info,
-    'reset',
-    '--hard',
-    $base_object_id
-  );
-  Gitprep::Util::run_command(@git_reset_hard_base_cmd)
-    or Carp::croak "Can't execute git reset --hard: @git_reset_hard_base_cmd";
+  Gitprep::Util::run_command(@git_branch_cmd)
+    or Carp::croak "Can't execute git checkout @git_branch_cmd";
 }
 
 sub merge {
   my ($self, $work_rep_info, $target_rep_info, $target_branch, $pull_request_number) = @_;
-  
-  my $object_id = $self->app->git->ref_to_object_id($target_rep_info, $target_branch);
+
+  my $target_remote = $target_rep_info->{user} . '/' . $target_rep_info->{project};
+  my $object_id = $self->app->git->ref_to_object_id($work_rep_info, "$target_remote/$target_branch");
   
   my $message;
   my $target_user_id = $target_rep_info->{user};
@@ -132,10 +146,11 @@ sub merge {
 
 sub get_patch {
   my ($self, $work_rep_info, $target_rep_info, $target_branch) = @_;
+
+  my $target_remote = $target_rep_info->{user} . '/' . $target_rep_info->{project};
+  my $object_id = $self->app->git->ref_to_object_id($work_rep_info, "$target_remote/$target_branch");
   
-  my $object_id = $self->app->git->ref_to_object_id($target_rep_info, $target_branch);
-  
-  # Merge
+  # Format patch
   my @git_format_patch_cmd = $self->app->git->cmd(
     $work_rep_info,
     'format-patch',
@@ -192,7 +207,7 @@ sub create_work_rep {
   my $work_rep_info = $self->app->work_rep_info($user, $project);
   my $work_tree = $work_rep_info->{work_tree};
   
-  # Create working repository if it don't exist
+  # Create working repository if it doesn't exist
   unless (-e $work_tree) {
 
     # git clone

--- a/templates/commit.html.ep
+++ b/templates/commit.html.ep
@@ -2,7 +2,7 @@
   # API
   my $api = gitprep_api;
   
-  # Paramters
+  # Parameters
   my $user_id = param('user');
   my $project_id = param('project');
   my $diff = param('diff');
@@ -131,30 +131,16 @@
         <li class="last-child">
           % my $parents = $commit->{parents};
           
-          % if (@$parents == 0) {
-            <div class="commits-summary-parent">
-              <span>0 parent</span>
-            </div>
-          % } elsif (@$parents == 1) {
-            <div class="commits-summary-parent">
-              <span>1 parent</span>
-              <a href="<%= url_for("$user_project_path/commit/$parents->[0]") %>">
-                <%= substr($parents->[0], 0, 7) %>
+          <div class="commits-summary-parent">
+            <span><%= $api->plural('parent', scalar @$parents, '0') %></span>
+            % my $sep = '';
+            % for my $parent (@$parents) {
+              <%= $sep %><a href="<%= url_for("$user_project_path/commit/$parent") %>">
+                <%= substr($parent, 0, 7) %>
               </a>
-            </div>
-          % } else {
-            <div class="commits-summary-parent">
-              <span>2 parents</span>:
-              
-              <a class="font-black" href="<%= url_for("$user_project_path/commit/$parents->[0]") %>">
-                <%= substr($parents->[0], 0, 7) %>
-              </a>
-              +
-              <a class="font-black" href="<%= url_for("$user_project_path/commit/$parents->[1]") %>">
-                <%= substr($parents->[1], 0, 7) %>
-              </a>
-            </div>
-          % }
+              % $sep = ' + ';
+            % }
+          </div>
           <div class="commits-summary-commit-id">
             commit <span><%= $commit->{id} %></span>
           </div>

--- a/templates/compare.html.ep
+++ b/templates/compare.html.ep
@@ -182,7 +182,7 @@
     $target_rep_info = $base_rep_info;
   }
     
-  # Create working repository if it don't exist
+  # Create working repository if it doesn't exist
   $self->app->manager->create_work_rep($base_user_id, $base_project_id);
   
   # Lock working repository
@@ -225,7 +225,8 @@
   my $authors_count = keys %$authors;
 
   # Start commit
-  my $start_commit_id = app->git->ref_to_object_id($base_rep_info, $base_branch);
+  my $start_commit_id = app->manager->merge_base($work_rep_info, $base_branch,
+    $target_rep_info, $target_branch);
 
   # End commit
   my $end_commit_id = app->git->ref_to_object_id($target_rep_info, $target_branch);
@@ -399,18 +400,21 @@
       <div>
         <div style="display:inline-block">
           <button id="base-fork-btn" class="btn btn-small" style="<%= $base_user_id eq $target_user_id ? 'display:none' : '' %>">
-            <span>base fork:</span><b> <%= $base_project->{'user.id'} %>/<%= $base_project->{id} %></b>
+            <span>base repository:</span><b> <%= $base_project->{'user.id'} %>/<%= $base_project->{id} %></b>
             %= $api->icon('arrow-down');
           </button>
           <button id="base-branch-btn" class="btn btn-small">
             <span>base:</span><b> <%= $base_branch %></b>
             %= $api->icon('arrow-down');
           </button>
-          ...
+        </div>
+        <div style="display:inline-block;line-height:0px;">
+          %= $api->icon('arrow-left');
+          <br />...
         </div>
         <div style="display:inline-block;margin-top:10px;">
           <button id="head-fork-btn" class="btn btn-small" style="<%= $base_user_id eq $target_user_id ? 'display:none' : '' %>">
-            <span>head fork:</span><b> <%= $target_project->{'user.id'} %>/<%= $target_project->{id} %></b>
+            <span>head repository:</span><b> <%= $target_project->{'user.id'} %>/<%= $target_project->{id} %></b>
             %= $api->icon('arrow-down');
           </button>
           <button id="target-branch-btn" class="btn btn-small">

--- a/templates/issue.html.ep
+++ b/templates/issue.html.ep
@@ -302,13 +302,16 @@
     # Working repository information
     my $work_rep_info = app->work_rep_info($base_user_id, $base_project_id);
 
+    # Make sure the working repository exists.
+    app->manager->create_work_rep($base_user_id, $base_project_id);
+
     # Display patch
     if (stash('patch')) {
       # Lock working repository
-      my $lock_fh = $self->app->manager->lock_rep($work_rep_info);
+      my $lock_fh = app->manager->lock_rep($work_rep_info);
 
       # Prepare merge
-      $self->app->manager->prepare_merge(
+      app->manager->prepare_merge(
         $work_rep_info,
         $base_rep_info,
         $base_branch,
@@ -317,7 +320,7 @@
       );
 
       # Create patch
-      my $patch = $self->app->manager->get_patch(
+      my $patch = app->manager->get_patch(
         $work_rep_info,
         $target_rep_info,
         $target_branch
@@ -329,7 +332,7 @@
     }
 
     # Git
-    my $git = $self->app->git;
+    my $git = app->git;
 
     # Handle pull-request specific requests.
     if (lc $self->req->method eq 'post') {
@@ -344,10 +347,10 @@
         }
 
         # Lock working repository
-        my $lock_fh = $self->app->manager->lock_rep($work_rep_info);
+        my $lock_fh = app->manager->lock_rep($work_rep_info);
 
         # Prepare merge
-        $self->app->manager->prepare_merge(
+        app->manager->prepare_merge(
           $work_rep_info,
           $base_rep_info,
           $base_branch,
@@ -356,7 +359,7 @@
         );
 
         # Merge
-        $merge_success = $self->app->manager->merge(
+        $merge_success = app->manager->merge(
           $work_rep_info,
           $target_rep_info,
           $target_branch
@@ -392,9 +395,20 @@
     }
     $last_commit_date = $commits->[0]->{committer_epoch} if @$commits;
 
+    my $lock_fh = app->manager->lock_rep($work_rep_info);
+
+    # Prepare merge
+    app->manager->prepare_merge(
+      $work_rep_info,
+      $base_rep_info,
+      $base_branch,
+      $target_rep_info,
+      $target_branch
+    );
+
     # Start commit
-    my $start_commit_id = app->git->ref_to_object_id($base_rep_info,
-      $base_branch);
+    my $start_commit_id = app->manager->merge_base($work_rep_info,
+      $base_branch, $target_rep_info, $target_branch);
 
     # End commit
     my $end_commit_id = app->git->ref_to_object_id($target_rep_info,
@@ -403,19 +417,8 @@
     # Check merge automatically
     if ($issue->{open}) {
 
-      my $lock_fh = $self->app->manager->lock_rep($work_rep_info);
-
-      # Prepare merge
-      $self->app->manager->prepare_merge(
-        $work_rep_info,
-        $base_rep_info,
-        $base_branch,
-        $target_rep_info,
-        $target_branch
-      );
-
       # Check conflicts
-      $merge_success = $self->app->manager->merge(
+      $merge_success = app->manager->merge(
         $work_rep_info,
         $target_rep_info,
         $target_branch


### PR DESCRIPTION
Hi Yuki,

This mainly deals with merge strategy and diff computations.
The temporary branch of the working repository is now only used for the merge itself and all branch references are done via remotes elsewhere.
I've also fixed the diff results for PR's. See commit comment.

Regards,
Patrick