### PR TITLE
Reduce git push time by speeding up git hooks start

### DIFF
--- a/lib/Gitprep/RPC.pm
+++ b/lib/Gitprep/RPC.pm
@@ -1,0 +1,89 @@
+package Gitprep::RPC;
+
+use Mojo::JSON qw(decode_json encode_json);
+
+# JSON-based RPC.
+# Used in git hook scripts to access app objects in gitprep git shell.
+
+sub new () {
+  my ($class, $send, $base) = @_;
+  my $self = {
+    input_buffer => '',
+    send => $send // sub {print shift},
+    base => $base
+  };
+  bless $self, $class;
+  return $self;
+}
+
+sub feed {
+  my ($self, $input) = @_;
+
+  # Append data to current input.
+  $self->{input_buffer} .= $input;
+}
+
+sub line {
+  my ($self, $peek) = @_;
+
+  # Get a full line from input buffer.
+  $self->{input_buffer} =~ /^(.*?)\n(.*)$/s or return undef;
+  $self->{input_buffer} = $2 unless $peek;
+  return $1;
+}
+
+# Server-side API.
+sub serve {
+  my ($self) = @_;
+
+  # Perform a request.
+  # They are transmitted has a json structure with the following fields:
+  # - code: Perl-syntax expression based at the RPC server base and using only
+  #         scalar/reference variables.
+  # - args: hash containing all variables referenced by code.
+  # The expression result is returned.
+  my $input = $self->line;
+  return 0 unless defined $input;
+  my $request = decode_json($input);
+
+  my $_base = $self->{base};
+  my $_code = $request->{code};
+  $_code = $_code? '$_base->' . $_code: 'undef';
+  my $_args = $request->{args} // {};
+  my @defs = (map 'my $' . $_ . '=$_args->{' . $_ . '};', keys(%$_args));
+  $_code = join('', @defs) . "return $_code;";
+  my $_reply;
+  {
+    $_reply = {reply => eval $_code};
+    $_reply = {error => $@} if $@;
+  }
+  $_reply = encode_json($_reply);
+  $_reply =~ s/[\r\n]//gs;
+  $self->{send}("$_reply\n");
+  return 1;
+}
+
+
+# Client-side API.
+sub request {
+  my $self = shift;
+  my $code = shift;
+
+  # Send a request.
+  my $request = encode_json({code => $code, args => {@_}});
+  $request =~ s/[\r\n]//gs;
+  $self->{send}("$request\n");
+}
+
+sub result {
+  my ($self) = @_;
+
+  # Decode and return a reply if available.
+  my $input = $self->line;
+  return undef unless defined $input;
+  $input = decode_json($input);
+  return ($input->{reply}, $input->{error}, 1);
+}
+
+
+1;

--- a/script/gitprep-post-receive
+++ b/script/gitprep-post-receive
@@ -7,25 +7,44 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use lib "$FindBin::Bin/../extlib/lib/perl5";
 use Mojo::URL;
-use Gitprep;
+use Gitprep::RPC;
+
+my $channel_fileno = 99;  # File descriptor number for RPC channel.
 
 # Retrieve our parameters
 my ($user_id, $project_id) = @ENV{'GITPREP_USER', 'GITPREP_PROJECT'};
 
 die "Gitprep parameters unset" unless $user_id && $project_id;
 
-my $app = Mojo::Server->new->load_app("$FindBin::Bin/gitprep");
-my $git = $app->git;
-my $dbi = $app->dbi;
+# Establish the RPC connection.
+open my $channel, "+<&=$channel_fileno" or die "Can't open request channel\n";
+my $rpc = Gitprep::RPC->new(sub {syswrite $channel, shift});
 
-my $rep_info = $app->rep_info($user_id, $project_id);
-my $default_branch = $git->current_branch($rep_info);
-my $project = $dbi->model('project')->select(
+sub rpc_call {
+  $rpc->request(@_);
+  my ($input, $result, $error, $gotit);
+  while (!$gotit) {
+    sysread $channel, $input, 2048 or die "Gitprep shell has exited\n";
+    $rpc->feed($input);
+    ($result, $error, $gotit) = $rpc->result;
+  }
+  die $error if $error;
+  return $result;
+}
+
+my $rep_info = rpc_call('rep_info($user_id, $project_id)',
+  user_id => $user_id,
+  project_id => $project_id
+);
+my $default_branch = rpc_call('git->current_branch($rep_info)',
+  rep_info => $rep_info
+);
+my $project = rpc_call('dbi->model("project")->select(where => $where)->one',
   where => {'user.id' => $user_id, 'project.id' => $project_id}
-)->one;
+);
 
 my $new_pr_path;
-my $url = $app->config->{basic}{new_pr_url};
+my $url = rpc_call('config->{basic}{new_pr_url}');
 if ($url) {
   $url = Mojo::URL->new($url);
   if ($url && $url->host) {

--- a/script/gitprep-pre-receive
+++ b/script/gitprep-pre-receive
@@ -6,9 +6,10 @@ use utf8;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use lib "$FindBin::Bin/../extlib/lib/perl5";
-use Gitprep;
+use Gitprep::RPC;
 
 my $debug = 0;
+my $channel_fileno = 99;  # File descriptor number for RPC channel.
 
 # Retrieve our parameters
 my ($session_user_id, $user_id, $project_id) =
@@ -16,18 +17,38 @@ my ($session_user_id, $user_id, $project_id) =
 
 die "Gitprep parameters unset" unless $session_user_id && $user_id && $project_id;
 
-my $app = Mojo::Server->new->load_app("$FindBin::Bin/gitprep");
-my $git = $app->git;
-my $dbi = $app->dbi;
-my $api = $app->gitprep_api;
-my $manager = $app->manager;
-my $rules = $manager->rules;
+# Establish the RPC connection.
+open my $channel, "+<&=$channel_fileno" or die "Can't open request channel\n";
+my $rpc = Gitprep::RPC->new(sub {syswrite $channel, shift});
 
-my $rep_info = $app->rep_info($user_id, $project_id);
-my $default_branch = $git->current_branch($rep_info);
-my $project_row_id = $dbi->model('project')->select('project.row_id',
-  where => {'user.id' => $user_id, 'project.id' => $project_id}
-)->value;
+sub rpc_call {
+  $rpc->request(@_);
+  my ($input, $result, $error, $gotit);
+  while (!$gotit) {
+    sysread $channel, $input, 2048 or die "Gitprep shell has exited\n";
+    $rpc->feed($input);
+    ($result, $error, $gotit) = $rpc->result;
+  }
+  die $error if $error;
+  return $result;
+}
+
+my $rules = rpc_call('manager->rules');
+
+my $rep_info = rpc_call('rep_info($user_id, $project_id)',
+  user_id => $user_id,
+  project_id => $project_id
+);
+my $default_branch = rpc_call('git->current_branch($rep_info)',
+  rep_info => $rep_info
+);
+my $project_row_id = rpc_call('dbi->model("project")->select("project.row_id",'.
+  'where => $where)->value',
+  where => {
+    'user.id' => $user_id,
+    'project.id' => $project_id
+  }
+);
 
 # Read project's active rulesets.
 my %where = (
@@ -35,13 +56,16 @@ my %where = (
   active => 1
 );
 $where{owner_bypass} = 0 if $session_user_id eq $user_id;
-my $rulesets = $dbi->model('ruleset')->select(
-  where => \%where,
-  append => 'order by name'
-)->all;
+my $rulesets = rpc_call('dbi->model("ruleset")->select(where => $where,' .
+  'append => "order by name")->all',
+  where => \%where
+);
 foreach my $ruleset (@$rulesets) {
-  $ruleset->{selector} = $manager->compile_ruleset_selectors($ruleset->{row_id},
-    $default_branch);
+  $ruleset->{selector} = rpc_call('manager->compile_ruleset_selectors(' .
+    '$ruleset_row_id, $default_branch)',
+    ruleset_row_id => $ruleset->{row_id},
+    default_ranch => $default_branch
+  );
 }
 
 # Check updates.
@@ -59,7 +83,10 @@ while (<>) {
   # Gather the checks to perform.
   my %checks;
   foreach my $ruleset (@$rulesets) {
-    if ($ruleset->{target} eq $kind && $manager->ruleset_selected($ruleset->{selector}, $name)) {
+    if ($ruleset->{target} eq $kind &&
+      rpc_call('manager->ruleset_selected($selector, $name)',
+        selector => $ruleset->{selector},
+        name => $name)) {
       foreach my $rule (@$rules) {
         push @{$checks{$rule->{id}}}, $ruleset->{name} if
           $ruleset->{$rule->{id}};
@@ -68,14 +95,20 @@ while (<>) {
   }
 
   # Perform the checks and issue messages.
+  my $index = 0;
   foreach my $rule (@$rules) {
     my $check = $checks{$rule->{id}};
-    if ($check && $rule->{check}->($rep_info, $old, $new, $ref)) {
+    if ($check && rpc_call('manager->rules->[$index]->{check}->(@$checkargs)',
+      index => $index,
+      checkargs => [$rep_info, $old, $new, $ref])
+    ) {
       $exit_status = 1;
       print "$kind '$name'$rule->{error} forbidden by ";
-      print $api->plural('ruleset', scalar(@$check));
+      print rpc_call('gitprep_api->plural("ruleset", $count)',
+        count => scalar(@$check));
       print ' ' . join(', ', @$check) . ".\n";
     }
+  $index++;
   }
 }
 

--- a/script/gitprep-shell-raw
+++ b/script/gitprep-shell-raw
@@ -8,8 +8,12 @@ use lib "$FindBin::Bin/../lib";
 use lib "$FindBin::Bin/../extlib/lib/perl5";
 use File::Copy qw/copy/;
 use Gitprep;
+use Gitprep::RPC;
+use Socket;
+use IO::Select;
 
 my $debug = 0;
+my $channel_fileno = 99;  # File descriptor number for request channel.
 
 # Project name pattern
 my $project_re = qr/$Gitprep::project_re$/;
@@ -88,14 +92,42 @@ if ($project_id !~ /\.wiki$/) {
   close $dh;
 }
 
+# Open the RPC channel for hooks.
+socketpair(my $clienth, my $serverh, AF_UNIX, SOCK_STREAM, PF_UNSPEC) or die "Can't establish request channel\n";
+POSIX::dup2($clienth->fileno, $channel_fileno);
+close $clienth;
+my $rpc = Gitprep::RPC->new(sub {syswrite $serverh, shift},$app);
 
 # Command
 my $repository = "'$rep_git_dir'";
 my @git_shell_cmd = ("git", "shell", "-c", "$verb $repository");
 warn "@git_shell_cmd" if $debug;
 unless ($debug) {
-  system(@git_shell_cmd) == 0
-    or die "Can't execute command: @git_shell_cmd\n" ;
+  open my $git_stdout, '-|', @git_shell_cmd
+    or die "Can't execute command: @git_shell_cmd\n";
+  my $select = IO::Select->new($git_stdout, $serverh);
+  my $shell_done;
+  my @fhs;
+  my $request = '';
+  my $reqlen;
+  while (!$shell_done) {
+    @fhs = ($select->can_read) unless @fhs;
+    my $fh = pop @fhs;
+    my $input;
+    if (!sysread $fh, $input, 2048) {
+      $select->remove($fh);
+      $shell_done = $fh == $git_stdout;
+    } elsif ($fh == $git_stdout) {
+        # Monitoring this handle is only useful for git shell exit detection.
+        # Thus just relay.
+        syswrite STDOUT, $input;
+    } elsif ($fh == $serverh) {
+      $rpc->feed($input);
+      while ($rpc->serve) {
+        # Just try serving another.
+      }
+    }
+  }
 }
 
 sub parse_ssh_original_command {


### PR DESCRIPTION
Hi Yuki,

This commit is a tentative to speed-up git remote operations, at the cost of a slightly less readable code.
See commit comment for more info.

I think we could save another 0.5 seconds if we can RPC the server itself, but needed Mojo features are out of my skill. In addition, it will require the gitprep server to run for git remote operations to be successful.

Cheers,
Patrick