### PR TITLE
Improve blob display

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,6 +635,7 @@ Even if shared hosting server, you can install Mojolicious application as CGI.
     requires 'Email::Sender', '== 2.600';
     requires 'HTML::Restrict', '== 3.0.0';
     requires 'Imager', '== 1.025';
+    requires 'Text::CSV', '== 2.06';
 
 If you want to install all defined modules, you only run the following command.
 
@@ -696,6 +697,7 @@ Thanks to Mojolicious author, [Sebastian riedel](https://x.com/kraih).
 * [Email::Sender](https://metacpan.org/pod/Email::Sender)
 * [HTML::Restrict](https://metacpan.org/pod/HTML::Restrict)
 * [Imager](https://metacpan.org/pod/Imager)
+* [Text::CSV](https://metacpan.org/pod/Text::CSV)
 
 ## Sister project
 

--- a/cpanfile
+++ b/cpanfile
@@ -22,3 +22,4 @@ requires 'HTML::FormatText::WithLinks';
 requires 'Email::Sender';
 requires 'HTML::Restrict', '== 3.0.0';
 requires 'Imager';
+requires 'Text::CSV';

--- a/public/css/common.css
+++ b/public/css/common.css
@@ -2618,6 +2618,47 @@ a:hover .btn-delete {
   border-radius: 0 0 2px 2px;
 }
 
+.blob-csv-container {
+  width: 100%;
+  overflow-x: auto;
+  padding-bottom: 12px;
+}
+
+.blob-csv {
+  border-spacing: 0;
+  font-size: 110%;
+}
+
+.blob-csv-header {
+  background-color: #e0e0e0;
+}
+
+.blob-csv-cell,
+.blob-csv-num {
+  border: 1px solid #e0e0e0;
+  padding: 6px 8px;
+  text-align: left;
+  white-space: nowrap;
+}
+
+.blob-csv-num {
+  text-align: right;
+  background-color: #e0e0e0;
+  padding-right: 12px;
+}
+
+.blob-pdf-container {
+  width: 100%;
+  aspect-ratio: 4/3;
+  border: 1px solid #e0e0e0;
+  margin-top: 6px;
+}
+
+.blob-pdf-object {
+  width: 100%;
+  height: 100%;
+}
+
 .commits {
   margin-top:20px;
 }

--- a/templates/blob.html.ep
+++ b/templates/blob.html.ep
@@ -43,14 +43,39 @@
   my $file_type = $git->file_type_long($mode);
   
   # MIME type
-  my $mime_type = $git->blob_mime_type($rep_info, $rev, $file);
+  my ($media_type, $media_subtype) = split '/',
+    lc($git->blob_mime_type($rep_info, $rev, $file));
 
-  # Blob lines(only text)
-  my $lines;
-  $lines = $git->blob($rep_info, $rev, $file) if $mime_type =~ /^text/;
+  # Call a blob sub-template.
+  local *call_template = sub {
+    my $template = shift;
+    my $blob_params = {
+                      rev => $rev,
+                      file => $file,
+                      media_type => $media_type,
+                      media_subtype => $media_subtype,
+                      rep_info => $rep_info,
+                      user_id_project_path => $user_id_project_path
+    };
+    my $html = $self->render_to_string($template, blob_params => $blob_params,
+                                       'mojo.maybe' => 1);
+    return unless $html;
+    $blob_params->{html} = $html;
+    return $blob_params;
+  };
 
-  # Variables for included template
-  stash(id => $rev, project => $project_id, rev => $rev);
+  # Try using a subtype-specific template.
+  my $blob_params;
+  $blob_params = call_template("/blob/$media_type/$media_subtype") unless param('subtype') // '' eq 'no';
+
+  # Fall back to a type-specific template.
+  $blob_params = call_template("/blob/$media_type") unless $blob_params;
+
+  # Variables for included templates
+  stash(id => $rev,
+        project => $project_id,
+        rev => $rev
+  );
 %>
 
 <% layout 'common' , title => "$project_id/$file at $rev \x{b7} $user_id/$project_id",
@@ -94,22 +119,23 @@
     <div>
       <div class="file-header">
         <div class="file-header-left">
-          % if ($lines) {
-            <%= @$lines %> lines
+          % if (defined $blob_params->{header_left}) {
+            %== $blob_params->{header_left};
             <span style="color:#dcdcdc">|</span>
           % }
           <%= $file_size %>kb
         </div>
         <div class="file-header-right">
+          % if (defined $blob_params->{header_right}) {
+            %== $blob_params->{header_right};
+          % }
           <ul>
+            % if (defined $blob_params->{buttons}) {
+              %== $blob_params->{buttons};
+            % }
             <li>
               <a class="btn btn-small" href="<%= url_for("$user_id_project_path/raw/$rev/$file") %>">Raw</a>
             </li>
-            % if ($mime_type =~ m#^text/#) {
-              <li>
-                <a class="btn btn-small" href="<%= url_for("$user_id_project_path/blame/$rev/$file") %>">Blame</a>
-              </li>
-            % }
             <li>
               <a class="btn btn-small" href="<%= url_for("$user_id_project_path/commits/$rev/$file") %>">
                 %= $api->icon('history');
@@ -120,34 +146,8 @@
         </div>
       </div>
     </div>
-    % if ($mime_type =~ m#^image/#) {
-      <div class="blob-image">
-        <img type="<%= $mime_type %>
-          % if (defined $file) {
-            alt="<%= $file %>" title="<%= $file %>"
-          % }
-          src="<%= url_for("$user_id_project_path/raw/$rev/$file") %>"
-        />
-      </div>
-    % } elsif ($mime_type =~ m#^text/#) {
-      % if ($file =~ /\.md$/) {
-        <%
-          my $readme = join "\n", @$lines;
-          my $subpath = $file;
-          $subpath =~ s#(?:^|/)[^/]*$##;
-          $subpath = "/$subpath" if $subpath;
-          $readme =~ s#^(\[.*\]:)(?!\s*https?://)\s*(\S*)#{"$1 " . url_for("$user_id_project_path/raw/$rev" . (substr($2, 0, 1) eq '/'? '': "$subpath/") . "$2")}#mge;
-          $readme =~ s#^(!\[.*\]\()(?!https?://)(\S*)#{$1 . url_for("$user_id_project_path/raw/$rev" . (substr($2, 0, 1) eq '/'? '': "$subpath/") . "$2")}#mge;
-          my $readme_e = $api->markdown($readme);
-        %>
-        <div class="readme-frame">
-          <div class="markdown-body">
-            <%== $readme_e %>
-          </div>
-        </div>
-      % } else {
-        <pre class="prettyprint linenums"><% for my $line (@$lines) { %><%= "$line\n" %><% } %></pre>
-      % }
+    % if (defined $blob_params->{html}) {
+      %= $blob_params->{html};
     % } else {
       <div class="blob-raw">
         <a href="<%= url_for("$user_id_project_path/raw/$rev/$file") %>">View raw</a>

--- a/templates/blob/application/pdf.html.ep
+++ b/templates/blob/application/pdf.html.ep
@@ -1,0 +1,12 @@
+<%
+  my $p = stash('blob_params');
+  my $pdf_url = url_for("$p->{user_id_project_path}/raw/$p->{rev}/$p->{file}");
+%>
+
+<div class="blob-pdf-container">
+  <object class="blob-pdf-object" data="<%= $pdf_url %>" type="application/pdf">
+    <p>
+      Your browser does not support PDFs.
+    </p>
+  </object>
+</div>

--- a/templates/blob/image.html.ep
+++ b/templates/blob/image.html.ep
@@ -1,0 +1,36 @@
+<%
+  # API
+  my $api = gitprep_api;
+
+  # Git
+  my $git = $self->app->git;
+
+  # Blob parameters.
+  my $p = stash('blob_params');
+
+  if ($p->{media_subtype} ne 'svg+xml') {
+    use Imager;
+
+    # Load image.
+    my $img = Imager->new(data => $git->blob_raw($p->{rep_info}, $p->{rev}, $p->{file}));
+
+    if ($img) {
+      my $width = $img->getwidth;
+      my $height = $img->getheight;
+      my $colormodel = $img->colormodel;
+      my $type = $img->type;
+      $p->{header_left} = "$width\x{d7}$height " . $api->plural('pixel', $width * $height) . ' ';
+      $p->{header_left} .= "$type " unless $type eq 'direct';
+      $p->{header_left} .= $colormodel unless ($colormodel // 'unknown') eq 'unknown';
+    }
+  }
+%>
+
+<div class="blob-image">
+  <img type="<%= $p->{media_type} %>/<%= $p->{media_subtype} %>
+    % if (defined $p->{file}) {
+      alt="<%= $p->{file} %>" title="<%= $p->{file} %>"
+    % }
+    src="<%= url_for("$p->{user_id_project_path}/raw/$p->{rev}/$p->{file}") %>"
+  />
+</div>

--- a/templates/blob/image/sgi.html.ep
+++ b/templates/blob/image/sgi.html.ep
@@ -1,0 +1,1 @@
+%= include '/blob/image/tiff';    # Same conversion process as for TIFF format.

--- a/templates/blob/image/tiff.html.ep
+++ b/templates/blob/image/tiff.html.ep
@@ -1,0 +1,37 @@
+<%
+  use MIME::Base64;
+  use Imager;
+
+  # API
+  my $api = gitprep_api;
+
+  # Git
+  my $git = $self->app->git;
+  
+  my $p = stash('blob_params');
+
+  # Load image.
+  my $img = Imager->new(data => $git->blob_raw($p->{rep_info}, $p->{rev}, $p->{file}));
+  return unless $img;
+
+  # Set info in header,
+  my $width = $img->getwidth;
+  my $height = $img->getheight;
+  my $colormodel = $img->colormodel;
+  my $type = $img->type;
+  $p->{header_left} = "$width\x{d7}$height " . $api->plural('pixel', $width * $height) . ' ';
+  $p->{header_left} .= "$type " unless $type eq 'direct';
+  $p->{header_left} .= $colormodel unless ($colormodel // 'unknown') eq 'unknown';
+
+  # Convert image to PNG data.
+  my $buffer;
+  $img->write(data => \$buffer, type => 'png');
+
+  # Encapsulate in SVG.
+  my $picture = encode_base64($buffer, '');
+  $picture = "<svg viewBox=\"0 0 $width $height\" width=\"$width\" height=\"$height\"><image href=\"data:image/png;base64,$picture\"></image></svg>";
+%>
+
+<div class="blob-image">
+  %== $picture;
+</div>

--- a/templates/blob/image/x-portable-anymap.html.ep
+++ b/templates/blob/image/x-portable-anymap.html.ep
@@ -1,0 +1,1 @@
+%= include '/blob/image/tiff';    # Same conversion process as for TIFF format.

--- a/templates/blob/text.html.ep
+++ b/templates/blob/text.html.ep
@@ -1,0 +1,18 @@
+<%
+  # API
+  my $api = gitprep_api;
+
+  # Git
+  my $git = $self->app->git;
+
+  # Blob parameters
+  my $p = stash('blob_params');
+
+  my $lines = $git->blob($p->{rep_info}, $p->{rev}, $p->{file});
+  $p->{header_left} = $api->plural('lines', scalar(@$lines), 'No');
+  $p->{buttons} = '<li><a class=btn btn-small" href="' . url_for("$p->{user_id_project_path}/blame/$p->{rev}/$p->{file}") . '">Blame</a></li>';
+%>
+
+% if (@$lines) {
+<pre class="prettyprint linenums"><% for my $line (@$lines) { %><%= "$line\n" %><% } %></pre>
+% }

--- a/templates/blob/text/csv.html.ep
+++ b/templates/blob/text/csv.html.ep
@@ -1,0 +1,57 @@
+<%
+  use Mojo::Util qw(xml_escape);
+  use Text::CSV;
+
+  # API
+  my $api = gitprep_api;
+
+  # Git
+  my $git = $self->app->git;
+
+  # Blob parameters
+  my $p = stash('blob_params');
+  my $sep_char = stash('sep_char') // ',';
+
+  my $lines = $git->blob($p->{rep_info}, $p->{rev}, $p->{file});
+  return unless @$lines;
+
+  # Parse lines.
+  my $records = [];
+  my $csv = Text::CSV->new({sep_char => $sep_char});
+  for my $line (@$lines) {
+    return unless $csv->parse($line);
+    my @fields = $csv->fields;
+    push @$records, \@fields;
+  }
+
+  # Set-up header fields.
+  $p->{header_left} = $api->plural('lines', scalar(@$lines), 'No');
+  $p->{buttons} = '<li><a class=btn btn-small" href="' . url_for("$p->{user_id_project_path}/blob/$p->{rev}/$p->{file}")->query(subtype => 'no') . '">Code</a></li>';
+  $p->{buttons} .= '<li><a class=btn btn-small" href="' . url_for("$p->{user_id_project_path}/blame/$p->{rev}/$p->{file}") . '">Blame</a></li>';
+
+  my $lineno = 1;
+  my $fieldtag = 'th';
+%>
+
+<div class="blob-csv-container">
+  <table class="blob-csv">
+    <thead class="blob-csv-header">
+      % for my $record (@$records) {
+        <tr class="blob-csv-row">
+          <td class="blob-csv-num"><%= $lineno %></td>
+          % for my $field (@$record) {
+            % $field =~ s/\s+$//;
+            % $field = xml_escape $field;
+            % $field =~ s/\s/&nbsp;/g;
+            <<%= $fieldtag %> class="blob-csv-cell"><%== $field %></<%= $fieldtag %>>
+          % }
+        </tr>
+        % if ($lineno == 1) {
+          </thead><tbody>
+          % $fieldtag = 'td',
+        % }
+        % $lineno++;
+      % }
+    </tbody>
+  </table>
+</div>

--- a/templates/blob/text/markdown.html.ep
+++ b/templates/blob/text/markdown.html.ep
@@ -1,0 +1,36 @@
+<%
+  # API
+  my $api = gitprep_api;
+
+  # Git
+  my $git = $self->app->git;
+
+  # Blob parameters
+  my $p = stash('blob_params');
+
+  my $lines = $git->blob($p->{rep_info}, $p->{rev}, $p->{file});
+  return unless @$lines;
+
+  # Set-up header fields.
+  $p->{header_left} = $api->plural('lines', scalar(@$lines), 'No');
+  $p->{buttons} = '<li><a class=btn btn-small" href="' . url_for("$p->{user_id_project_path}/blob/$p->{rev}/$p->{file}")->query(subtype => 'no') . '">Code</a></li>';
+  $p->{buttons} .= '<li><a class=btn btn-small" href="' . url_for("$p->{user_id_project_path}/blame/$p->{rev}/$p->{file}") . '">Blame</a></li>';
+
+  my $readme = join "\n", @$lines;
+  my $subpath = $p->{file};
+  $subpath =~ s#(?:^|/)[^/]*$##;
+  $subpath = "/$subpath" if $subpath;
+  $readme =~ s#^(\[.*\]:)(?!\s*https?://)\s*(\S*)#{"$1 " .
+             url_for("$p->{user_id_project_path}/raw/$p->{rev}" .
+             (substr($2, 0, 1) eq '/'? '': "$subpath/") . "$2")}#mge;
+  $readme =~ s#^(!\[.*\]\()(?!https?://)(\S*)#{$1 .
+             url_for("$p->{user_id_project_path}/raw/$p->{rev}" .
+             (substr($2, 0, 1) eq '/'? '': "$subpath/") . "$2")}#mge;
+  my $readme_e = $api->markdown($readme);
+%>
+
+<div class="readme-frame">
+  <div class="markdown-body">
+    <%== $readme_e %>
+  </div>
+</div>

--- a/templates/blob/text/tab-separated-values.html.ep
+++ b/templates/blob/text/tab-separated-values.html.ep
@@ -1,0 +1,1 @@
+%= include '/blob/text/csv', sep_char => "\t";


### PR DESCRIPTION
Hi Yuki,

I hope you doing well.
After a long months pause, I come back with a commit that will interest you, I think. Here are the features:

Add specific display support for the following file extensions:
- apng, avif, bmp, cur, ico, jfif, pjp, pjpeg, sgi and webp images using browser rendering.
- pbm, pgm, pnm, ppm, sgi, tif and tiff images by converting them to an inline SVG-embedded PNM.
- pdf documents using the browser rendering capability, if some.
- csv and tsv data as tables.

Text specific renderers (md, csv, tsv) implement a "code" button to revert to canonical text rendering.

Image file header displays the image size and color model when available.

The csv and tsv renderers use the additional module Text::CSV.

File types are only based on name extension: they should also take data introspection into account.

Fixes #140

P.S.: I have packaged gitprep for Fedora and RHEL: see https://copr.fedorainfracloud.org/coprs/monnerat/gitprep/
This makes the installation (system-wide) very easy.