### PR TITLE
Fix pull request merge.

### DIFF
--- a/templates/issue.html.ep
+++ b/templates/issue.html.ep
@@ -371,7 +371,11 @@
 
         if ($merge_success) {
           # Push
-          app->manager->push($work_rep_info, $base_branch);
+          {
+            local %ENV = %ENV;
+            app->manager->prepare_hooks($api->session_user_id, $base_rep_info);
+            app->manager->push($work_rep_info, $base_branch);
+          }
 
           # Close
           app->dbi->model('issue')->update(

--- a/templates/issue.html.ep
+++ b/templates/issue.html.ep
@@ -390,6 +390,17 @@
       }
     }
 
+    my $lock_fh = app->manager->lock_rep($work_rep_info);
+
+    # Prepare merge, sync work repo.
+    app->manager->prepare_merge(
+      $work_rep_info,
+      $base_rep_info,
+      $base_branch,
+      $target_rep_info,
+      $target_branch
+    );
+
     # Commits
     $commits = $git->forward_commits(
       $work_rep_info,
@@ -398,21 +409,11 @@
       $target_rep_info,
       $target_branch
     );
+
     for my $commit (@$commits) {
       $authors->{$commit->{author}} = $commit;
     }
     $last_commit_date = $commits->[0]->{committer_epoch} if @$commits;
-
-    my $lock_fh = app->manager->lock_rep($work_rep_info);
-
-    # Prepare merge
-    app->manager->prepare_merge(
-      $work_rep_info,
-      $base_rep_info,
-      $base_branch,
-      $target_rep_info,
-      $target_branch
-    );
 
     # Start commit
     my $start_commit_id = app->manager->merge_base($work_rep_info,


### PR DESCRIPTION
Pushing the merge result to the base repository currently fails because the environment variables needed by the hooks are not set for a local push (i.e.: neither http nor ssh, but direct fs access).

Ensure these environment variables are set and the hooks copied to the base repository when pushing the merge.


I just added a 2nd commit to fix another problem. See the commit message for a description.
Regards,
Patrick