### PR TITLE
Objectify rep_info

### DIFF
--- a/lib/Gitprep.pm
+++ b/lib/Gitprep.pm
@@ -12,6 +12,7 @@ use DBIx::Custom;
 use Gitprep::API;
 use Gitprep::Git;
 use Gitprep::Manager;
+use Gitprep::Repository;
 use Scalar::Util 'weaken';
 use Validator::Custom;
 use Time::Moment;
@@ -37,82 +38,6 @@ has 'manager';
 has 'vc';
 
 use constant BUFFER_SIZE => 8192;
-
-sub data_dir {
-  my $self = shift;
-  
-  my $data_dir = $self->config('data_dir');
-  
-  return $data_dir;
-}
-
-sub rep_home {
-  my $self = shift;
-  
-  my $rep_home = $self->data_dir . "/rep";
-  
-  return $rep_home;
-}
-
-sub rep_info {
-  my ($self, $user_id, $project_id) = @_;
-  
-  my $info = {};
-  $info->{user} = $user_id;
-  $info->{project} = $project_id;
-  $info->{root} = $self->rep_home . "/$user_id/$project_id.git";
-  $info->{git_dir} = $info->{root};
-  $info->{url} = "/$user_id/$project_id";
-  
-  return $info;
-}
-
-sub work_rep_home {
-  my $self = shift;
-  
-  my $work_rep_home = $self->data_dir . "/work";
-  
-  return $work_rep_home;
-}
-
-sub work_rep_info {
-  my ($self, $user_id, $project_id) = @_;
-  
-  my $info = {};
-  $info->{user} = $user_id;
-  $info->{project} = $project_id;
-  $info->{root} = $self->work_rep_home . "/$user_id/$project_id";
-  $info->{git_dir} = $info->{root} . '/.git';
-  $info->{work_tree} = $info->{root};
-  
-  return $info;
-}
-
-sub wiki_rep_info {
-  my ($self, $user_id, $project_id) = @_;
-  
-  my $info = {};
-  $info->{user} = $user_id;
-  $info->{project} = $project_id;
-  $info->{root} = $self->rep_home . "/$user_id/$project_id.wiki.git";
-  $info->{git_dir} = $info->{root};
-  $info->{url} = "/$user_id/$project_id/wiki";
-  
-  return $info;
-}
-
-sub wiki_work_rep_info {
-  my ($self, $user_id, $project_id) = @_;
-  
-  my $info = {};
-  $info->{user} = $user_id;
-  $info->{project} = $project_id;
-  $info->{root} = $self->work_rep_home . "/$user_id/$project_id.wiki";
-  $info->{git_dir} = $info->{root} . '/.git';
-  $info->{work_tree} = $info->{root};
-  
-  return $info;
-}
 
 sub sign {
   my $self = shift;
@@ -183,6 +108,10 @@ sub startup {
   my $data_dir = $ENV{GITPREP_DATA_DIR} ? $ENV{GITPREP_DATA_DIR} : $self->home->rel_file('data');
   $self->config(data_dir => $data_dir);
 
+  # Configure Repository package.
+  Gitprep::Repository->home("$data_dir/rep");
+  Gitprep::Repository::Work->home("$data_dir/work");
+
   if (my $custom_templates = $conf->{templates}{custom_template_folder}) {
     die "$custom_templates folder not found or not writable! Giving up ..." unless (-d $custom_templates && -w $custom_templates);
     unshift(@{$self->renderer->paths}, $custom_templates);
@@ -224,7 +153,7 @@ sub startup {
   }
   
   # Repository home
-  my $rep_home = "$data_dir/rep";
+  my $rep_home = Gitprep::Repository->home;
   unless (-d $rep_home) {
     mkdir $rep_home
       or croak "Can't create directory $rep_home: $!";

--- a/lib/Gitprep/API.pm
+++ b/lib/Gitprep/API.pm
@@ -12,6 +12,8 @@ use HTML::Restrict;
 use Carp 'croak';
 use Encode 'decode', 'encode';
 
+use Gitprep::Repository;
+
 has 'cntl';
 
 sub markdown_wiki {
@@ -48,7 +50,8 @@ sub markdown_wiki {
 sub exists_wiki_page {
   my ($self, $user_id, $project_id, $title) = @_;
   
-  my $wiki_work_rep_info = $self->app->wiki_work_rep_info($user_id, $project_id);
+  my $wiki_work_rep_info = Gitprep::Repository::Wiki->new($user_id,
+    $project_id)->work;
   
   # File name
   my $file_name = $title;
@@ -57,7 +60,7 @@ sub exists_wiki_page {
   $file_name .= '.md';
   
   # File abs name
-  my $file_abs_name = "$wiki_work_rep_info->{work_tree}/$file_name";
+  my $file_abs_name = $wiki_work_rep_info->work_tree($file_name);
   
   my $exists = -f encode('UTF-8', $file_abs_name);
   
@@ -67,10 +70,11 @@ sub exists_wiki_page {
 sub get_wiki_pages {
   my ($self, $user_id, $project_id) = @_;
   
-  my $wiki_work_rep_info = $self->app->wiki_work_rep_info($user_id, $project_id);
+  my $wiki_work_rep_info = Gitprep::Repository::Wiki->new($user_id,
+    $project_id)->work;
   
   # Open directory
-  my $dir = $wiki_work_rep_info->{work_tree};
+  my $dir = $wiki_work_rep_info->work_tree;
   opendir my $dh, $dir
     or croak "Can't open directory \"$dir\":$!";
   
@@ -91,10 +95,11 @@ sub get_wiki_pages {
 sub get_wiki_pages_count {
   my ($self, $user_id, $project_id) = @_;
   
-  my $wiki_work_rep_info = $self->app->wiki_work_rep_info($user_id, $project_id);
+  my $wiki_work_rep_info = Gitprep::Repository::Wiki->new($user_id,
+    $project_id)->work;
   
   # Open directory
-  my $dir = $wiki_work_rep_info->{work_tree};
+  my $dir = $wiki_work_rep_info->work_tree;
   opendir my $dh, $dir
     or croak "Can't open directory \"$dir\":$!";
   
@@ -113,7 +118,8 @@ sub get_wiki_pages_count {
 sub get_wiki_page_content {
   my ($self, $user_id, $project_id, $title) = @_;
   
-  my $wiki_work_rep_info = $self->app->wiki_work_rep_info($user_id, $project_id);
+  my $wiki_work_rep_info = Gitprep::Repository::Wiki->new($user_id,
+    $project_id)->work;
   
   # File name
   my $file_name = $title;
@@ -122,7 +128,7 @@ sub get_wiki_page_content {
   $file_name .= '.md';
   
   # File abs name
-  my $file_abs_name = "$wiki_work_rep_info->{work_tree}/$file_name";
+  my $file_abs_name = $wiki_work_rep_info->work_tree($file_name);
   
   unless (-f encode('UTF-8', $file_abs_name)) {
     return;
@@ -170,8 +176,8 @@ sub create_wiki_page {
   }
   
   # Update page
-  my $wiki_work_rep_info = $self->app->wiki_work_rep_info($user_id, $project_id);
-  my $wiki_rep_info = $self->app->wiki_rep_info($user_id, $project_id);
+  my $wiki_rep_info = Gitprep::Repository::Wiki->new($user_id, $project_id);
+  my $wiki_work_rep_info = $wiki_rep_info->work;
   
   # File name
   my $file_name = $title;
@@ -180,7 +186,7 @@ sub create_wiki_page {
   $file_name .= '.md';
   
   # File abs name
-  my $file_abs_name = "$wiki_work_rep_info->{work_tree}/$file_name";
+  my $file_abs_name = $wiki_work_rep_info->work_tree($file_name);
   
   open my $fh, '>:encoding(UTF-8)', encode('UTF-8', $file_abs_name)
     or die "Can't open file \"". encode('UTF-8', $file_abs_name) . "\": $!";
@@ -198,7 +204,7 @@ sub create_wiki_page {
       $wiki_work_rep_info,
       'status',
       '-s',
-      $wiki_work_rep_info->{work_tree}
+      $wiki_work_rep_info->work_tree
     );
     open my $fh, '-|', @git_status_cmd
       or croak "Can't execute @git_status_cmd";
@@ -214,7 +220,7 @@ sub create_wiki_page {
   my @git_add_cmd = $self->app->git->cmd(
     $wiki_work_rep_info,
     'add',
-    $wiki_work_rep_info->{work_tree}
+    $wiki_work_rep_info->work_tree
   );
   
   Gitprep::Util::run_command(@git_add_cmd)
@@ -237,7 +243,7 @@ sub create_wiki_page {
       $wiki_work_rep_info,
       'push',
       '-q',
-      $wiki_rep_info->{git_dir},
+      $wiki_rep_info->git_dir,
       'master'
     );
     # (This is bad, but --quiet option can't supress in old git)
@@ -253,9 +259,9 @@ sub rename_and_update_wiki_page {
   my $project_row_id = $self->get_project_row_id($user_id, $project_id);
   
   # Update page
-  my $wiki_work_rep_info = $self->app->wiki_work_rep_info($user_id, $project_id);
-  my $wiki_rep_info = $self->app->wiki_rep_info($user_id, $project_id);
-  
+  my $wiki_rep_info = Gitprep::Repository::Wiki->new($user_id, $project_id);
+  my $wiki_work_rep_info = $wiki_rep_info->work;
+
   # Original file name
   my $original_file_name = $original_title;
   $original_file_name =~ s/^ +//;
@@ -269,10 +275,10 @@ sub rename_and_update_wiki_page {
   $file_name .= '.md';
 
   # Original file abs name
-  my $original_file_abs_name = "$wiki_work_rep_info->{work_tree}/$original_file_name";
+  my $original_file_abs_name = $wiki_work_rep_info->work_tree($original_file_name);
   
   # File abs name
-  my $file_abs_name = "$wiki_work_rep_info->{work_tree}/$file_name";
+  my $file_abs_name = $wiki_work_rep_info->work_tree($file_name);
   
   # Create file
   open my $fh, '>:encoding(UTF-8)', encode('UTF-8', $file_abs_name)
@@ -297,7 +303,7 @@ sub rename_and_update_wiki_page {
       $wiki_work_rep_info,
       'status',
       '-s',
-      $wiki_work_rep_info->{work_tree}
+      $wiki_work_rep_info->work_tree
     );
     open my $fh, '-|', @git_status_cmd
       or croak "Can't execute @git_status_cmd";
@@ -323,7 +329,7 @@ sub rename_and_update_wiki_page {
   my @git_add_cmd = $self->app->git->cmd(
     $wiki_work_rep_info,
     'add',
-    $wiki_work_rep_info->{work_tree}
+    $wiki_work_rep_info->work_tree
   );
   
   Gitprep::Util::run_command(@git_add_cmd)
@@ -346,7 +352,7 @@ sub rename_and_update_wiki_page {
       $wiki_work_rep_info,
       'push',
       '-q',
-      $wiki_rep_info->{git_dir},
+      $wiki_rep_info->git_dir,
       'master'
     );
     # (This is bad, but --quiet option can't supress in old git)
@@ -363,19 +369,19 @@ sub delete_wiki_page {
   
   # Get wiki
   my $wiki = $self->app->dbi->model('wiki')->select(where => {project => $project_row_id})->one;
-  
-  # Wiki working directory
-  my $wiki_work_rep_info = $self->app->wiki_work_rep_info($user_id, $project_id);
-  
+
   # Wiki repository
-  my $wiki_rep_info = $self->app->wiki_rep_info($user_id, $project_id);
+  my $wiki_rep_info = Gitprep::Repository::Wiki->new($user_id, $project_id);
+
+  # Wiki working directory
+  my $wiki_work_rep_info = $wiki_rep_info->work;
   
   # File name
   my $file_name = $title;
   $file_name .= '.md';
   
   # File abs name
-  my $file_abs_name = "$wiki_work_rep_info->{work_tree}/$file_name";
+  my $file_abs_name = $wiki_work_rep_info->work_tree($file_name);
   
   # Delete file
   if (-f encode('UTF-8', $file_abs_name)) {
@@ -390,7 +396,7 @@ sub delete_wiki_page {
       $wiki_work_rep_info,
       'status',
       '-s',
-      $wiki_work_rep_info->{work_tree}
+      $wiki_work_rep_info->work_tree
     );
     open my $fh, '-|', @git_status_cmd
       or croak "Can't execute @git_status_cmd";
@@ -430,7 +436,7 @@ sub delete_wiki_page {
       $wiki_work_rep_info,
       'push',
       '-q',
-      $wiki_rep_info->{git_dir},
+      $wiki_rep_info->git_dir,
       'master'
     );
     # (This is bad, but --quiet option can't supress in old git)
@@ -665,13 +671,13 @@ sub mentioned {
 sub ssh_rep_url {
   my ($self, $user_id, $repository) = @_;
 
-  my $app = $self->app;
-  my $user = $app->config->{basic}{ssh_user} || getpwuid($>);
-  my $port = $app->config->{basic}{ssh_port};
-  my $home = $app->config->{basic}{'ssh_rep_url_base'} || $app->rep_home;
+  my $config = $self->app->config;
+  my $user = $config->{basic}{ssh_user} || getpwuid($>);
+  my $port = $config->{basic}{ssh_port};
+  my $home = $config->{basic}{'ssh_rep_url_base'} || Gitprep::Repository->home;
   my $url = "$user@" . $self->cntl->url_for->to_abs->host;
 
-  if (!$app->config->{basic}{scp_url} || $port) {
+  if (!$config->{basic}{scp_url} || $port) {
     # True ssh url.
     $url .= ":$port" if $port;
     return "ssh://$url$home/$user_id/$repository.git";

--- a/lib/Gitprep/Git.pm
+++ b/lib/Gitprep/Git.pm
@@ -203,21 +203,15 @@ sub branches_count {
 
 sub cmd {
   my ($self, $rep_info, @command) = @_;
-  
+
   $rep_info //= {};
-  
-  my $git_dir = $rep_info->{git_dir};
-  my $work_tree = $rep_info->{work_tree};
+  my $git_dir = $rep_info->git_dir if $rep_info->can('git_dir');
+  my $work_tree = $rep_info->work_tree if $rep_info->can('work_tree');
   
   my @command_all = ($self->bin);
-  if (defined $git_dir) {
-    push @command_all, "--git-dir=$git_dir";
-  }
-  if (defined $work_tree) {
-    push @command_all, "--work-tree=$work_tree";
-  }
+  push @command_all, "--git-dir=$git_dir" if defined $git_dir;
+  push @command_all, "--work-tree=$work_tree" if defined $work_tree;
   push @command_all, @command;
-  
   return @command_all;
 }
 
@@ -695,13 +689,12 @@ sub delete_branch {
 sub description {
   my ($self, $rep_info, $description) = @_;
   
-  my $git_dir = $rep_info->{git_dir};
-  my $file = "$git_dir/description";
+  my $file = $rep_info->git_dir('description');
   
   if (defined $description) {
     # Write description
     open my $fh, '>',$file
-      or croak "Can't open file $git_dir: $!";
+      or croak "Can't open file $file $!";
     print $fh encode('UTF-8', $description)
       or croak "Can't write description: $!";
     close $fh;
@@ -1003,7 +996,7 @@ sub object_type {
 sub repository {
   my ($self, $rep_info) = @_;
 
-  return unless -d $rep_info->{git_dir};
+  return unless -d $rep_info->git_dir;
   
   my $rep = {updated => $self->last_activity($rep_info)};
   my $description = $self->description($rep_info) || '';
@@ -1520,11 +1513,10 @@ sub import_branch {
   my $force = $opt->{force};
   
   # Git pull
-  my $remote_rep = $remote_rep_info->{git_dir};
   my @cmd = $self->cmd(
     $rep_info,
     'fetch',
-    $remote_rep,
+    $remote_rep_info->git_dir,
     ($force ? '+' : '') . "refs/heads/$remote_branch:refs/heads/$branch"
   );
   
@@ -1729,7 +1721,7 @@ sub decide_encoding {
   
   my $guess_encoding_str = $self->app->dbi->model('project')->select(
     'guess_encoding',
-    where => {user_id => $rep_info->{user}, name => $rep_info->{project}}
+    where => {user_id => $rep_info->user, name => $rep_info->project}
   )->value;
   
   my @guess_encodings;

--- a/lib/Gitprep/Manager.pm
+++ b/lib/Gitprep/Manager.pm
@@ -11,6 +11,7 @@ use Carp 'croak';
 use File::Spec;
 use Scalar::Util 'weaken';
 use Gitprep::Util;
+use Gitprep::Repository;
 
 has 'app';
 has 'authorized_keys_file';
@@ -37,22 +38,22 @@ sub prepare_merge {
   my $git = $self->app->git;
 
   # Fetch base repository
-  my $base_user_id = $base_rep_info->{user};
+  my $base_user_id = $base_rep_info->user;
   my @git_fetch_base_cmd = $git->cmd($work_rep_info, 'fetch', 'origin');
   Gitprep::Util::run_command(@git_fetch_base_cmd)
     or Carp::croak "Can't execute git fetch: @git_fetch_base_cmd";
 
   # Configure remote for target repository
-  my $target_remote = $target_rep_info->{user} . '/' . $target_rep_info->{project};
+  my $target_remote = $target_rep_info->remote_name;
   my $remotes = $self->get_remotes($work_rep_info);
-  if (exists $remotes->{$target_remote} && $remotes->{$target_remote} ne $target_rep_info->{root}) {
+  if (exists $remotes->{$target_remote} && $remotes->{$target_remote} ne $target_rep_info->root) {
     my @git_remote_remove_cmd = $git->cmd($work_rep_info, 'remote', 'remove', $target_remote);
     Gitprep::Util::run_command(@git_remote_remove_cmd)
       or Carp::croak "Can't execute git remote @git_remote_remove_cmd";
     delete $remotes->{$target_remote};
   }
   if (!exists $remotes->{$target_remote}) {
-    my @git_remote_add_cmd = $git->cmd($work_rep_info, 'remote', 'add', $target_remote, $target_rep_info->{root});
+    my @git_remote_add_cmd = $git->cmd($work_rep_info, 'remote', 'add', $target_remote, $target_rep_info->root);
     Gitprep::Util::run_command(@git_remote_add_cmd)
       or Carp::croak "Can't execute git remote @git_remote_add_cmd";
   }
@@ -117,11 +118,11 @@ sub prepare_merge {
 sub merge {
   my ($self, $work_rep_info, $target_rep_info, $target_branch, $pull_request_number) = @_;
 
-  my $target_remote = $target_rep_info->{user} . '/' . $target_rep_info->{project};
+  my $target_remote = $target_rep_info->remote_name;
   my $object_id = $self->app->git->ref_to_object_id($work_rep_info, "$target_remote/$target_branch");
   
   my $message;
-  my $target_user_id = $target_rep_info->{user};
+  my $target_user_id = $target_rep_info->user;
   if (defined $pull_request_number) {
     $message = "Merge pull request #$pull_request_number from $target_user_id/$target_branch";
   }
@@ -147,7 +148,7 @@ sub merge {
 sub get_patch {
   my ($self, $work_rep_info, $target_rep_info, $target_branch) = @_;
 
-  my $target_remote = $target_rep_info->{user} . '/' . $target_rep_info->{project};
+  my $target_remote = $target_rep_info->remote_name;
   my $object_id = $self->app->git->ref_to_object_id($work_rep_info, "$target_remote/$target_branch");
   
   # Format patch
@@ -169,7 +170,7 @@ sub get_patch {
 sub merge_base {
   my ($self, $work_rep_info, $base_branch, $target_rep_info, $target_branch) = @_;
 
-  my $target_remote = $target_rep_info->{user} . '/' . $target_rep_info->{project};
+  my $target_remote = $target_rep_info->remote_name;
   my @git_merge_base_cmd = $self->app->git->cmd(
     $work_rep_info,
     'merge-base',
@@ -200,8 +201,7 @@ sub push {
 sub lock_rep {
   my ($self, $rep_info) = @_;
   
-  my $git_dir = $rep_info->{git_dir};
-  my $lock_file = "$git_dir/config";
+  my $lock_file = $rep_info->git_dir('config');
   
   open my $lock_fh, '<', $lock_file
     or croak "Can't open lock file $lock_file: $!";
@@ -216,18 +216,21 @@ sub create_work_rep {
   my ($self, $user, $project) = @_;
   
   # Remote repository
-  my $rep_info = $self->app->rep_info($user, $project);
-  my $rep_git_dir = $rep_info->{git_dir};
+  my $rep_info = Gitprep::Repository->new($user, $project);
   
   # Working repository
-  my $work_rep_info = $self->app->work_rep_info($user, $project);
-  my $work_tree = $work_rep_info->{work_tree};
+  my $work_rep_info = $rep_info->work;
   
   # Create working repository if it doesn't exist
-  unless (-e $work_tree) {
+  unless (-e $work_rep_info->work_tree) {
 
     # git clone
-    my @git_clone_cmd = ($self->app->git->bin, 'clone', $rep_git_dir, $work_tree);
+    my @git_clone_cmd = (
+      $self->app->git->bin,
+      'clone',
+      $rep_info->git_dir,
+      $work_rep_info->work_tree
+    );
     Gitprep::Util::run_command(@git_clone_cmd)
       or croak "Can't git clone: @git_clone_cmd";
     
@@ -563,9 +566,8 @@ sub rename_project {
   my ($self, $user, $project, $to_project) = @_;
   
   # Rename project
-  my $app = $self->app;
-  my $git = $app->git;
-  my $dbi = $app->dbi;
+  my $git = $self->app->git;
+  my $dbi = $self->app->dbi;
   my $has_wiki = $dbi->model('wiki')->select('count(*)', where => {
     'project.id' => $project
   })->value;
@@ -575,22 +577,18 @@ sub rename_project {
       eval { $self->_rename_project($user, $project, $to_project) };
       croak $error = $@ if $@;
 
-      eval { $self->_rename_rep($user, $project, $to_project, sub () {
-        return $app->rep_info(@_);}
-      ) };
+      eval { $self->_rename_rep($user, $project, $to_project,
+        sub { return shift; }); };
       croak $error = $@ if $@;
-      eval { $self->_rename_rep($user, $project, $to_project, sub () {
-        return $app->work_rep_info(@_);}
-      ) };
+      eval { $self->_rename_rep($user, $project, $to_project,
+        sub { return shift->work; }); };
       croak $error = $@ if $@;
       if ($has_wiki) {
-        eval { $self->_rename_rep($user, $project, $to_project, sub () {
-          return $app->wiki_rep_info(@_);}
-        ) };
+        eval { $self->_rename_rep($user, $project, $to_project,
+          sub { return shift->wiki; }); };
         croak $error = $@ if $@;
-        eval { $self->_rename_rep($user, $project, $to_project, sub () {
-          return $app->wiki_work_rep_info(@_);}
-        ) };
+        eval { $self->_rename_rep($user, $project, $to_project,
+          sub { return shift->wiki->work; }); };
         croak $error = $@ if $@;
       }
     });
@@ -762,8 +760,8 @@ sub _create_rep {
   # Create repository directory
   my $git = $self->app->git;
 
-  my $rep_info = $self->app->rep_info($user, $project);
-  my $rep_git_dir = $rep_info->{git_dir};
+  my $rep_info = Gitprep::Repository->new($user, $project);
+  my $rep_git_dir = $rep_info->git_dir;
   
   mkdir $rep_git_dir
     or croak "Can't create directory $rep_git_dir: $!";
@@ -820,88 +818,92 @@ sub _create_rep {
       my $temp_dir =  File::Temp->newdir(DIR => $home_tmp_dir);
       
       # Working repository
-      my $work_rep_work_tree = "$temp_dir/work";
-      my $work_rep_git_dir = "$work_rep_work_tree/.git";
-      my $work_rep_info = {
-        work_tree => $work_rep_work_tree,
-        git_dir => $work_rep_git_dir
-      };
-      
-      mkdir $work_rep_work_tree
-        or croak "Can't create directory $work_rep_work_tree: $!";
-      
-      # Git init
-      my @work_repo_cmd = ($work_rep_info, 'init', '-q');
-      if ($default_branch ne 'master') {
-        CORE::push( @work_repo_cmd, '--initial-branch=' . $default_branch );
-      }
-      my @git_init_cmd = $git->cmd(@work_repo_cmd);
-      Gitprep::Util::run_command(@git_init_cmd)
-        or croak "Can't execute git init: @git_init_cmd";
-      
-      # Add README
-      my $file = "$work_rep_work_tree/README.md";
-      open my $readme_fh, '>', $file
-        or croak "Can't create $file: $!";
-      print $readme_fh "# $project\n";
-      print $readme_fh "\n" . encode('UTF-8', $description) . "\n";
-      close $readme_fh;
-      
-      my @git_add_cmd = $git->cmd(
-        $work_rep_info,
-        'add',
-        'README.md'
-      );
-      
-      Gitprep::Util::run_command(@git_add_cmd)
-        or croak "Can't execute git add: @git_add_cmd";
-      
-      # Set user name
-      my @git_config_user_name = $git->cmd(
-        $work_rep_info,
-        'config',
-        'user.name',
-        $user
-      );
-      Gitprep::Util::run_command(@git_config_user_name)
-        or croak "Can't execute git config: @git_config_user_name";
-      
-      # Set user email
-      my $user_email = $self->app->dbi->model('user')->select('email', where => {id => $user})->value;
-      my @git_config_user_email = $git->cmd(
-        $work_rep_info,
-        'config',
-        'user.email',
-        "$user_email"
-      );
-      Gitprep::Util::run_command(@git_config_user_email)
-        or croak "Can't execute git config: @git_config_user_email";
-      
-      # Commit
-      my @git_commit_cmd = $git->cmd(
-        $work_rep_info,
-        'commit',
-        '-q',
-        '-m',
-        'first commit'
-      );
+      my $work_rep_info = $rep_info->work;
+      # Override leading path to our temporary directory.
+      $work_rep_info->home($temp_dir);
 
-      Gitprep::Util::run_command(@git_commit_cmd)
-        or croak "Can't execute git commit: @git_commit_cmd";
-      
-      # Push
-      {
-        my @git_push_cmd = $git->cmd(
+      mkpath($work_rep_info->work_tree)
+        or croak "Can't create directory " . $work_rep_info->work_tree . ": $!";
+
+      eval {
+        # Git init
+        my @work_repo_cmd = (
           $work_rep_info,
-          'push',
+          'init',
           '-q',
-          $rep_git_dir,
-          $default_branch
+          "--initial-branch=$default_branch"
         );
-        # (This is bad, but --quiet option can't supress in old git)
-        Gitprep::Util::run_command(@git_push_cmd)
-          or croak "Can't execute git push: @git_push_cmd";
-      }
+        my @git_init_cmd = $git->cmd(@work_repo_cmd);
+        Gitprep::Util::run_command(@git_init_cmd)
+          or croak "Can't execute git init: @git_init_cmd";
+
+        # Add README
+        my $file = $work_rep_info->work_tree('README.md');
+        open my $readme_fh, '>', $file
+          or croak "Can't create $file: $!";
+        print $readme_fh "# $project\n";
+        print $readme_fh "\n" . encode('UTF-8', $description) . "\n";
+        close $readme_fh;
+      
+        my @git_add_cmd = $git->cmd(
+          $work_rep_info,
+          'add',
+          'README.md'
+        );
+
+        Gitprep::Util::run_command(@git_add_cmd)
+          or croak "Can't execute git add: @git_add_cmd";
+
+        # Set user name
+        my @git_config_user_name = $git->cmd(
+          $work_rep_info,
+          'config',
+          'user.name',
+          $user
+        );
+        Gitprep::Util::run_command(@git_config_user_name)
+          or croak "Can't execute git config: @git_config_user_name";
+
+        # Set user email
+        my $user_email = $self->app->dbi->model('user')->select('email', where => {id => $user})->value;
+        my @git_config_user_email = $git->cmd(
+          $work_rep_info,
+          'config',
+          'user.email',
+          "$user_email"
+        );
+        Gitprep::Util::run_command(@git_config_user_email)
+          or croak "Can't execute git config: @git_config_user_email";
+      
+        # Commit
+        my @git_commit_cmd = $git->cmd(
+          $work_rep_info,
+          'commit',
+          '-q',
+          '-m',
+          'first commit'
+        );
+
+        Gitprep::Util::run_command(@git_commit_cmd)
+          or croak "Can't execute git commit: @git_commit_cmd";
+      
+        # Push
+        {
+          my @git_push_cmd = $git->cmd(
+            $work_rep_info,
+            'push',
+            '-q',
+            $rep_git_dir,
+            $default_branch
+          );
+          # (This is bad, but --quiet option can't supress in old git)
+          Gitprep::Util::run_command(@git_push_cmd)
+            or croak "Can't execute git push: @git_push_cmd";
+        }
+      };
+      my $e = $@;
+      rmtree $temp_dir;
+      croak $e if $e;
     }
   };
   if (my $e = $@) {
@@ -916,8 +918,8 @@ sub create_wiki_rep {
   # Create repository directory
   my $git = $self->app->git;
   
-  my $wiki_rep_info = $self->app->wiki_rep_info($user, $project);
-  my $wiki_rep_git_dir = $wiki_rep_info->{git_dir};
+  my $wiki_rep_info = Gitprep::Repository::Wiki->new($user, $project);
+  my $wiki_rep_git_dir = $wiki_rep_info->git_dir;
   
   mkdir $wiki_rep_git_dir
     or croak "Can't create directory $wiki_rep_git_dir: $!";
@@ -932,7 +934,7 @@ sub create_wiki_rep {
     
     # Add git-daemon-export-ok
     {
-      my $file = "$wiki_rep_git_dir/git-daemon-export-ok";
+      my $file = $wiki_rep_info->git_dir('git-daemon-export-ok');
       open my $fh, '>', $file
         or croak "Can't create git-daemon-export-ok: $!"
     }
@@ -958,18 +960,21 @@ sub create_wiki_work_rep {
   my ($self, $user, $project) = @_;
   
   # Remote repository
-  my $wiki_rep_info = $self->app->wiki_rep_info($user, $project);
-  my $wiki_rep_git_dir = $wiki_rep_info->{git_dir};
+  my $wiki_rep_info = Gitprep::Repository::Wiki->new($user, $project);
   
   # Working repository
-  my $wiki_work_rep_info = $self->app->wiki_work_rep_info($user, $project);
-  my $work_tree = $wiki_work_rep_info->{work_tree};
+  my $wiki_work_rep_info = $wiki_rep_info->work;
   
   # Create working repository if it don't exist
-  unless (-e $work_tree) {
+  unless (-e $wiki_work_rep_info->work_tree) {
 
     # git clone
-    my @git_clone_cmd = ($self->app->git->bin, 'clone', $wiki_rep_git_dir, $work_tree);
+    my @git_clone_cmd = (
+      $self->app->git->bin,
+      'clone',
+      $wiki_rep_info->git_dir,
+      $wiki_work_rep_info->work_tree
+    );
     Gitprep::Util::run_command(@git_clone_cmd)
       or croak "Can't git clone: @git_clone_cmd";
     
@@ -1009,7 +1014,7 @@ sub _create_user_dir {
   my ($self, $user) = @_;
   
   # Create user directory
-  my $rep_home = $self->app->rep_home;
+  my $rep_home = Gitprep::Repository->home;
   my $user_dir = "$rep_home/$user";
   mkpath $user_dir;
 }
@@ -1048,7 +1053,7 @@ sub _delete_user_dir {
   my ($self, $user) = @_;
   
   # Delete user directory
-  my $rep_home = $self->app->rep_home;
+  my $rep_home = Gitprep::Repository->home;
   my $user_dir = "$rep_home/$user";
   rmtree $user_dir;
 }
@@ -1215,12 +1220,12 @@ sub _delete_rep {
   my ($self, $user, $project) = @_;
 
   # Delete repository
-  my $rep_home = $self->app->rep_home;
+  my $rep_home = Gitprep::Repository->home;
   croak "Can't remove repository. repository home is empty"
     if !defined $rep_home || $rep_home eq '';
-  my $app = $self->app;
-  for my $ri ($app->rep_info($user, $project), $app->work_rep_info($user, $project)) {
-    my $rep = $ri->{root};
+  my $rep_info = Gitprep::Repository->new($user, $project);
+  for my $ri ($rep_info, $rep_info->work) {
+    my $rep = $ri->root;
     if (-e $rep) {
       rmtree $rep;
       croak "Can't remove repository. repository is rest"
@@ -1233,9 +1238,9 @@ sub _delete_wiki_rep {
   my ($self, $user, $project) = @_;
 
   # Delete wiki repository
-  my $app = $self->app;
-  for my $ri ($app->wiki_rep_info($user, $project), $app->wiki_work_rep_info($user, $project)) {
-    my $rep =  $ri->{root};
+  my $rep_info = Gitprep::Repository::Wiki->new($user, $project);
+  for my $ri ($rep_info, $rep_info->work) {
+    my $rep =  $ri->root;
     if (-e $rep) {
       rmtree $rep;
       croak "Can't remove wiki repository"
@@ -1269,10 +1274,8 @@ sub _exists_rep {
   my ($self, $user, $project) = @_;
   
   # Exists repository
-  my $rep_info = $self->app->rep_info($user, $project);
-  my $rep_git_dir = $rep_info->{git_dir};
-  
-  return -e $rep_git_dir;
+  my $rep_info = Gitprep::Repository->new($user, $project);
+  return -e $rep_info->git_dir;
 }
 
 sub _fork_rep {
@@ -1281,11 +1284,8 @@ sub _fork_rep {
   # Fork repository
   my $git = $self->app->git;
   
-  my $rep_info = $self->app->rep_info($user_id, $project_id);
-  my $rep_git_dir = $rep_info->{git_dir};
-  
-  my $to_rep_info = $self->app->rep_info($to_user_id, $to_project_id);
-  my $to_rep_git_dir = $to_rep_info->{git_dir};
+  my $rep_info = Gitprep::Repository->new($user_id, $project_id);
+  my $to_rep_info = Gitprep::Repository->new($to_user_id, $to_project_id);
 
   my @cmd = (
     $git->bin,
@@ -1293,8 +1293,8 @@ sub _fork_rep {
     '-q',
     '--bare',
     $single? '--single-branch': (),
-    $rep_git_dir,
-    $to_rep_git_dir
+    $rep_info->git_dir,
+    $to_rep_info->git_dir
   );
   Gitprep::Util::run_command(@cmd)
     or croak "Can't fork repository(_fork_rep): @cmd";
@@ -1303,7 +1303,7 @@ sub _fork_rep {
     $git->description($to_rep_info, $description);
   } else {
     # Copy description
-    copy "$rep_git_dir/description", "$to_rep_git_dir/description"
+    copy $rep_info->git_dir('description'), $to_rep_info->git_dir('description')
       or croak "Can't copy description file(_fork_rep)";
   }
 }
@@ -1333,16 +1333,17 @@ sub _rename_rep {
     unless defined $user && defined $project && defined $renamed_project;
 
   # Rename repository
-  my $rep_info = $info_func->($user, $project);
-  my $rep_git_dir = $rep_info->{root};
+  my $rep_info = $info_func->(Gitprep::Repository->new($user, $project));
+  my $rep_root = $rep_info->root;
 
-  my $renamed_rep_info = $info_func->($user, $renamed_project);
-  my $renamed_rep_git_dir = $renamed_rep_info->{root};
+  my $renamed_rep_info =
+    $info_func->(Gitprep::Repository->new($user, $renamed_project));
+  my $renamed_rep_root = $renamed_rep_info->root;
 
-  if (-e $rep_git_dir) {
+  if (-e $rep_root) {
     my $lock_fh = $self->lock_rep($rep_info);
-    move($rep_git_dir, $renamed_rep_git_dir)
-      or croak "Can't move $rep_git_dir to $renamed_rep_git_dir: $!";
+    move($rep_root, $renamed_rep_root)
+      or croak "Can't move $rep_root to $renamed_rep_root $!";
   }
 }
 
@@ -1359,8 +1360,8 @@ sub rename_branch {
     my $project_row_id = $dbi->model('project')->select(
       'project.row_id',
       where => {
-        'user.id' => $rep_info->{user},
-        'project.id' => $rep_info->{project}
+        'user.id' => $rep_info->user,
+        'project.id' => $rep_info->project
       }
     )->value;
     $git->move_branch($rep_info, $old, $new);
@@ -1384,19 +1385,18 @@ sub prepare_hooks {
   # Copy hook stubs to the targeted repository if needed and set
   # environment variables as expected by these hooks.
 
-  my $user_id = $rep_info->{user};
-  my $project_id = $rep_info->{root};
+  my $user_id = $rep_info->user;
+  my $project_id = $rep_info->root;
   $project_id =~ s#^.*/([^/]*)\.git$#$1# or croak "Invalid repository name $project_id";
 
   # Copy fresh hook stubs.
   if ($project_id !~ /\.wiki$/) {
     my $hookdir = $self->app->home . '/script/hooks';
-    my $rep_git_dir = $rep_info->{git_dir};
     opendir my $dh, $hookdir or die "Can't open hooks directory\n";
     while (readdir $dh) {
       my $src = "$hookdir/$_";
       next unless (-f $src) && -x $src;
-      my $dst = "$rep_git_dir/hooks/$_";
+      my $dst = $rep_info->git_dir("hooks/$_");
       if (!(-x $dst) || (stat($src))[9] > (stat($dst))[9]) {
         copy $src, $dst;
         chmod((stat($dst))[2] | 0555, $dst) or die "Can't install $_ hook\n";

--- a/lib/Gitprep/Repository.pm
+++ b/lib/Gitprep/Repository.pm
@@ -1,0 +1,97 @@
+package Gitprep::Repository;
+
+use Gitprep::Repository::Wiki;
+use Gitprep::Repository::Work;
+
+my $home;
+
+use constant _project_suffix => '';
+use constant _url_suffix => '';
+
+# Create a new repository information object.
+# If called via an existing object, the user and project default to the latter.
+sub new {
+  my ($self, $user, $project) = @_;
+
+  if (ref($self)) {
+    $user //= $self->user;
+    $project //= $self->project;
+    $self = ref($self);
+  }
+  return bless {
+    user => $user,
+    project => $project
+  }, $self;
+}
+
+# Return the repository owner.
+sub user { return shift->{user}; }
+
+# Return the repository project name.
+sub project { return shift->{project}; }
+
+# Return wether the repository is a wiki.
+sub is_wiki { return shift->isa('Gitprep::Repository::Wiki')? 1: 0; }
+
+# Getter/setter for the home property.
+# If called for the class, change the default.
+sub home {
+  my ($self, $home_dir) = @_;
+
+  if (ref($self)) {
+    $self->{home} = $home_dir if defined $home_dir;
+    return $self->{home} if exists $self->{home};
+  }
+  $home = $home_dir if defined $home_dir;
+  return $home;
+}
+
+# Return the repository's top level directory.
+sub root {
+  my ($self, $file) = shift;
+  my $home = $self->home;
+  my $wiki = $self->_project_suffix;
+  return $self->_path("$home/$self->{user}/$self->{project}$wiki.git", $file);
+}
+
+# Return the repository's directory where git support files are located.
+sub git_dir { return shift->root(@_); }
+
+# Return the url for the repository.
+sub url {
+  my ($self, $file) = @_;
+  my $wiki = $self->_url_suffix;
+  return $self->_path("/$self->{user}/$self->{project}$wiki", $file);
+}
+
+# Return a suitable unambiguous name for an upstream repository.
+sub remote_name {
+  my $self = shift; 
+  my $wiki = $self->_project_suffix;
+  return "repo/$self->{user}/$self->{project}$wiki";
+}
+
+# Return a bare repository matching the object, whatever variant is the latter.
+sub repo { return Gitprep::Repository->new($self->user, $self->project); }
+
+# Return a wiki repository matching the object, whatever variant is the latter.
+sub wiki {
+  my $self = shift;
+  return Gitprep::Repository::Wiki->new($self->user, $self->project);
+}
+
+# Return a work repository whose origin is the object.
+sub work { return Gitprep::Repository::Work->new(@_); }
+
+# Protected method to cleanly concatenate paths.
+sub _path {
+  my ($self, $path, $file) = @_;
+  $file //= '';
+  $file =~ s#^/*(.*?)/*$#$1#;
+  $file =~ s#/+$#/#g;
+  $path .= "/$file" if $file ne '';
+  return $path;
+}
+
+
+1;

--- a/lib/Gitprep/Repository/Wiki.pm
+++ b/lib/Gitprep/Repository/Wiki.pm
@@ -1,0 +1,9 @@
+package Gitprep::Repository::Wiki;
+
+use parent Gitprep::Repository;
+
+use constant _project_suffix => '.wiki';
+use constant _url_suffix => '/wiki';
+
+
+1;

--- a/lib/Gitprep/Repository/Work.pm
+++ b/lib/Gitprep/Repository/Work.pm
@@ -1,0 +1,68 @@
+package Gitprep::Repository::Work;
+
+use Gitprep::Repository;
+
+my $home;
+
+# Create a new work repository information object.
+sub new {
+  my $self = shift;
+  my $origin = $_[0];
+
+  unless (ref($origin)) {
+    $origin = $self;
+    $origin = Gitprep::Repository->new(@_) unless ref($origin);
+  }
+  $origin = $origin->origin if $origin->isa('Gitprep::Repository::Work');
+
+  return bless {
+    origin => $origin
+  }, $self;
+}
+
+sub origin { return shift->{origin}; }
+
+# Getter/setter for the home property.
+# If called for the class, change the default.
+sub home {
+  my ($self, $home_dir) = @_;
+
+  if (ref($self)) {
+    $self->{home} = $home_dir if defined $home_dir;
+    return $self->{home} if exists $self->{home};
+  }
+  $home = $home_dir if defined $home_dir;
+  return $home;
+}
+
+sub user { return shift->origin->user(@_); }
+sub project { return shift->origin->project(@_); }
+sub is_wiki { return shift->origin->is_wiki(@_); }
+sub repo { return shift->origin->repo(@_); }
+sub wiki { return shift->origin->wiki(@_); }
+sub work { return shift->new(@_); }
+
+sub root {
+  my ($self, $file) = @_;
+  my $home = $self->home;
+  my $origin = $self->origin;
+  my $user = $origin->user;
+  my $project = $origin->project;
+  my $is_wiki = $origin->_project_suffix;
+  return $origin->_path("$home/$user/$project$is_wiki", $file);
+}
+
+sub git_dir {
+  my ($self, $file) = @_;
+  my $root = $self->root;
+  return $self->origin->_path("$root/.git", $file);
+}
+
+# Return the top level directory for the project files.
+sub work_tree {
+  my ($self, $file) = @_;
+  return $self->root($file);
+}
+
+
+1;

--- a/script/gitprep-post-receive
+++ b/script/gitprep-post-receive
@@ -8,6 +8,7 @@ use lib "$FindBin::Bin/../lib";
 use lib "$FindBin::Bin/../extlib/lib/perl5";
 use Mojo::URL;
 use Gitprep;
+use Gitprep::Repository;
 
 # Retrieve our parameters
 my ($user_id, $project_id) = @ENV{'GITPREP_USER', 'GITPREP_PROJECT'};
@@ -18,7 +19,7 @@ my $app = Mojo::Server->new->load_app("$FindBin::Bin/gitprep");
 my $git = $app->git;
 my $dbi = $app->dbi;
 
-my $rep_info = $app->rep_info($user_id, $project_id);
+my $rep_info = Gitprep::Repository->new($user_id, $project_id);
 my $default_branch = $git->current_branch($rep_info);
 my $project = $dbi->model('project')->select(
   where => {'user.id' => $user_id, 'project.id' => $project_id}

--- a/script/gitprep-pre-receive
+++ b/script/gitprep-pre-receive
@@ -7,6 +7,7 @@ use FindBin;
 use lib "$FindBin::Bin/../lib";
 use lib "$FindBin::Bin/../extlib/lib/perl5";
 use Gitprep;
+use Gitprep::Repository;
 
 my $debug = 0;
 
@@ -23,7 +24,7 @@ my $api = $app->gitprep_api;
 my $manager = $app->manager;
 my $rules = $manager->rules;
 
-my $rep_info = $app->rep_info($user_id, $project_id);
+my $rep_info = Gitprep::Repository->new($user_id, $project_id);
 my $default_branch = $git->current_branch($rep_info);
 my $project_row_id = $dbi->model('project')->select('project.row_id',
   where => {'user.id' => $user_id, 'project.id' => $project_id}

--- a/script/gitprep-shell-raw
+++ b/script/gitprep-shell-raw
@@ -8,6 +8,7 @@ use lib "$FindBin::Bin/../lib";
 use lib "$FindBin::Bin/../extlib/lib/perl5";
 use File::Copy qw/copy/;
 use Gitprep;
+use Gitprep::Repository;
 
 my $debug = 0;
 
@@ -67,11 +68,11 @@ die qq|User "$session_user_id" can't access repository "$user_id/$project_id.git
   unless $can_access; 
 
 # Prepare hooks execution.
-my $rep_info = $app->rep_info($user_id, $project_id);
+my $rep_info = Gitprep::Repository->new($user_id, $project_id);
 $manager->prepare_hooks($session_user_id, $rep_info);
 
 # Command
-my $repository = "'$rep_info->{git_dir}'";
+my $repository = "'" . $rep_info->git_dir . "'";
 my @git_shell_cmd = ("git", "shell", "-c", "$verb $repository");
 warn "@git_shell_cmd" if $debug;
 unless ($debug) {

--- a/script/import_rep
+++ b/script/import_rep
@@ -9,6 +9,7 @@ use lib "$FindBin::Bin/../extlib/lib/perl5";
 use Getopt::Long qw(:config default no_auto_abbrev no_ignore_case);
 use File::Basename 'basename';
 use Gitprep;
+use Gitprep::Repository;
 use Encode 'decode';
 use Mojo::Server;
 
@@ -84,7 +85,8 @@ for my $rep (glob "$rep_dir/*") {
       }
     };
     $description = decode('UTF-8', $description);
-    eval {$git->description(app->rep_info($user_id, $project_id), $description) };
+    my $remote_rep_info = Gitprep::Repository->new($user_id, $project_id);
+    eval {$git->description($remote_rep_info, $description) };
     if ($@) {
       warn "Can't update description $project_id\n";
     }
@@ -92,20 +94,17 @@ for my $rep (glob "$rep_dir/*") {
     # Push repository
     chdir $rep
       or warn "Can't change directory $rep: $!\n";
-    
-    my $remote_rep_info = $app->rep_info($user_id, $project_id);
-    my $remote_rep_git_dir = $remote_rep_info->{git_dir};
-    
+
     # push branches
     {
-      my @cmd = ('git', 'push', $remote_rep_git_dir, '--all');
+      my @cmd = ('git', 'push', $remote_rep_info->git_dir, '--all');
       system(@cmd) == 0
         or warn "Can't push branches: @cmd";
     }
     
     # push tags
     {
-      my @cmd = ('git', 'push', $remote_rep_git_dir, '--tags');
+      my @cmd = ('git', 'push', $remote_rep_info->git_dir, '--tags');
       system(@cmd) == 0
         or warn "Can't push tags: @cmd";
     }

--- a/t/rep_info.t
+++ b/t/rep_info.t
@@ -1,0 +1,118 @@
+use Test::More 'no_plan';
+
+use FindBin;
+use lib "$FindBin::Bin/../lib";
+use lib "$FindBin::Bin/../extlib/lib/perl5";
+
+use List::Util 'uniq';
+use Gitprep::Repository;
+
+my @cases = (
+  {
+    stimulus => {
+      class       => 'Gitprep::Repository',
+      user        => 'user1',
+      project     => 'project1',
+      classhome   => '/bare_home'
+    },
+    expected => {
+      home        => '/bare_home',
+      user        => 'user1',
+      project     => 'project1',
+      root        => '/bare_home/user1/project1.git',
+      git_dir     => '/bare_home/user1/project1.git',
+      url         => '/user1/project1',
+      remote_name => 'repo/user1/project1',
+      is_wiki     => 0
+    }
+  },
+  {
+    stimulus => {
+      class       => 'Gitprep::Repository::Work',
+      user        => 'yuki-kimoto',
+      project     => 'SPVM',
+      classhome   => '/work_home'
+    },
+    expected => {
+      home        => '/work_home',
+      user        => 'yuki-kimoto',
+      project     => 'SPVM',
+      root        => '/work_home/yuki-kimoto/SPVM',
+      git_dir     => '/work_home/yuki-kimoto/SPVM/.git',
+      work_tree   => '/work_home/yuki-kimoto/SPVM',
+      is_wiki     => 0
+    }
+  },
+  {
+    stimulus => {
+      class       => 'Gitprep::Repository::Work',
+      user        => 'Linus',
+      project     => 'kernel',
+      home        => '/tempdir'
+    },
+    expected => {
+      home        => '/tempdir',
+      user        => 'Linus',
+      project     => 'kernel',
+      root        => '/tempdir/Linus/kernel',
+      git_dir     => '/tempdir/Linus/kernel/.git',
+      work_tree   => '/tempdir/Linus/kernel',
+      is_wiki     => 0
+    }
+  },
+  {
+    stimulus => {
+      class       => 'Gitprep::Repository::Wiki',
+      user        => 'u',
+      project     => 'p',
+    },
+    expected => {
+      home        => '/bare_home',
+      user        => 'u',
+      project     => 'p',
+      root        => '/bare_home/u/p.wiki.git',
+      git_dir     => '/bare_home/u/p.wiki.git',
+      url         => '/u/p/wiki',
+      remote_name => 'repo/u/p.wiki',
+      is_wiki     => 1
+    }
+  },
+  {
+    stimulus => {
+      class       => 'Gitprep::Repository::Wiki',
+      user        => 'pm',
+      project     => 'gitprep',
+      is_work     => 1
+    },
+    expected => {
+      home        => '/work_home',
+      user        => 'pm',
+      project     => 'gitprep',
+      root        => '/work_home/pm/gitprep.wiki',
+      git_dir     => '/work_home/pm/gitprep.wiki/.git',
+      work_tree   => '/work_home/pm/gitprep.wiki',
+      is_wiki     => 1
+    }
+  }
+);
+
+for (@cases) {
+  my $stimulus = $_->{stimulus};
+  my $expected = $_->{expected};
+  $stimulus->{class}->home($stimulus->{classhome}, $stimulus->{is_work})
+    if defined $stimulus->{classhome};
+  my $rep_info = $stimulus->{class}->new($stimulus->{user},
+    $stimulus->{project}, $stimulus->{is_work});
+  $rep_info = $rep_info->work if $stimulus->{is_work};
+  $rep_info->home($stimulus->{home}) if defined $stimulus->{home};
+  my %result;
+  for my $method ('home', 'user', 'project', 'root', 'git_dir',
+    'url', 'work_tree', 'remote_name', 'is_wiki') {
+   $result{$method} = $rep_info->$method if $rep_info->can($method);
+  }
+  for my $method (sort(uniq(keys(%result), keys(%$expected)))) {
+    my $is_work = $stimulus->{is_work}? '(work)': '';
+    is ($result{$method}, $expected->{$method},
+      "$stimulus->{class}$is_work $stimulus->{project}: $method");
+  }
+}

--- a/templates/api/diff_fold.html.ep
+++ b/templates/api/diff_fold.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   use Mojo::JSON 'decode_json';
 
   my $user_id = param('user');
@@ -15,7 +17,8 @@
   if ($is_wiki) {
     $user_id_project_path .= '/wiki';
   }
-  my $rep_info = $is_wiki? app->wiki_rep_info($user_id, $project_id): app->rep_info($user_id, $project_id);
+  my $rep_info = Gitprep::Repository->new($user_id, $project_id);
+  $rep_info = $rep_info->wiki if $is_wiki;
   my ($rev, $file) = $git->parse_rev_path($rep_info, $rev_file);
 
   my $huge = 1000000000;

--- a/templates/api/revs.html.ep
+++ b/templates/api/revs.html.ep
@@ -1,16 +1,20 @@
 <%
+  use Gitprep::Repository;
+
   my $api = gitprep_api;
   
   # Git
   my $git = app->git;
+
+  my $rep_info = Gitprep::Repository->new($user, $project);
   
   # Branches
-  my $branches = $git->branches($self->app->rep_info($user, $project)) || [];
+  my $branches = $git->branches($rep_info) || [];
   my @branch_names = map { $_->{name} } @$branches;
   
   # Tags
   my $tags = $git->tags(
-    app->rep_info($user, $project),
+    $rep_info,
     app->config->{basic}{tags_limit} || 1000,
     app->config->{basic}{tags_limit} || 1000
   ) || [];

--- a/templates/archive.html.ep
+++ b/templates/archive.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   # API
   my $api = $self->gitprep_api;
   
@@ -25,8 +27,10 @@
   # Git
   my $git = app->git;
 
+  my $rep_info = Gitprep::Repository->new($user, $project);
+
   # Object type
-  my $type = $git->object_type(app->rep_info($user, $project), "$rev^{}");
+  my $type = $git->object_type($rep_info, "$rev^{}");
   if (!$type || $type eq 'blob') {
     $self->reply->not_found;
     return;
@@ -41,7 +45,7 @@
   };
   my $cmd = quote(
     $git->cmd(
-      app->rep_info($user, $project),
+      $rep_info,
       'archive',
       "--format=$format",
       "--prefix=$name/",

--- a/templates/auto/_search.html.ep
+++ b/templates/auto/_search.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   my $api = gitprep_api;
 
   # Parameters
@@ -113,7 +115,7 @@
                 <%
                   my $user_id = $project->{'user.id'};
                   my $project_id = $project->{id};
-                  my $rep_info = app->rep_info($user_id, $project_id);
+                  my $rep_info = Gitprep::Repository->new($user_id, $project_id);
                   my $rev = app->git->current_branch($rep_info);
                   my $desc = app->git->description($rep_info);
                   my $branches = app->git->branches($rep_info);

--- a/templates/blame.html.ep
+++ b/templates/blame.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   # API
   my $api = gitprep_api;
 
@@ -15,7 +17,8 @@
   if ($is_wiki) {
     $user_project_path .= '/wiki';
   }
-  my $rep_info = $is_wiki ? app->wiki_rep_info($user_id, $project_id) : app->rep_info($user_id, $project_id);
+  my $rep_info = Gitprep::Repository->new($user_id, $project_id);
+  $rep_info = $rep_info->wiki if $is_wiki;
 
   my ($rev, $file) = $git->parse_rev_path($rep_info, $rev_file);
   if (!$git->rev_exists($rep_info, $rev) || !$git->file_exists($rep_info, $rev, $file)) {

--- a/templates/blob.html.ep
+++ b/templates/blob.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   # API
   my $api = gitprep_api;
 
@@ -15,7 +17,8 @@
   if ($is_wiki) {
     $user_id_project_path .= '/wiki';
   }
-  my $rep_info = $is_wiki ? app->wiki_rep_info($user_id, $project_id) : app->rep_info($user_id, $project_id);
+  my $rep_info = Gitprep::Repository->new($user_id, $project_id);
+  $rep_info = $rep_info->wiki if $is_wiki;
 
   my ($rev, $file) = $git->parse_rev_path($rep_info, $rev_file);
 

--- a/templates/branches.html.ep
+++ b/templates/branches.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   # API
   my $api = gitprep_api;
 
@@ -13,7 +15,7 @@
 
   my $session_user_id = $api->session_user_id;
   my $canadmin = $api->logined && $api->can_write_access($session_user_id, $user_id, $project_id);
-  my $rep_info = app->rep_info($user_id, $project_id);
+  my $rep_info = Gitprep::Repository->new($user_id, $project_id);
 
   # Default branch
   my $default_branch_name = $git->current_branch($rep_info);
@@ -333,16 +335,15 @@
                       if ($original_project) {
                         my $original_user_id = $original_project->{'user.id'};
                         my $original_project_id = $original_project->{id};
+                        my $original_rep_info = Gitprep::Repository->new($original_user_id, $original_project_id);
 
                         my $exists_original_branch_name = app->git->exists_branch(
-                          app->rep_info($original_user_id, $original_project_id),
-                          $branch_name
-                        );
+                          $original_rep_info, $branch_name);
                         if ($exists_original_branch_name) {
                           $compare_url = url_for("/$original_user_id/$original_project_id/compare/$branch_name...$user_id:$project_id:$branch_name")->query(expand => 1);
                         }
                         else {
-                          my $original_project_default_branch = $git->current_branch(app->rep_info($original_user_id, $original_project_id));
+                          my $original_project_default_branch = $git->current_branch($original_rep_info);
                           $compare_url = url_for("/$original_user_id/$original_project_id/compare/$original_project_default_branch...$user_id:$project_id:$branch_name")->query(expand => 1);
                         }
                       }

--- a/templates/commit.html.ep
+++ b/templates/commit.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   # API
   my $api = gitprep_api;
   
@@ -14,7 +16,8 @@
   if ($is_wiki) {
     $user_project_path .= '/wiki';
   }
-  my $rep_info = $is_wiki ? app->wiki_rep_info($user_id, $project_id) : app->rep_info($user_id, $project_id);
+  my $rep_info = Gitprep::Repository->new($user_id, $project_id);
+  $rep_info = $rep_info->wiki if $is_wiki;
 
   # Git
   my $git = app->git;

--- a/templates/commits.html.ep
+++ b/templates/commits.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   # API
   my $api = gitprep_api;
 
@@ -18,9 +20,10 @@
   }
   
   my $render_atom_feed = $rev_file =~ s/\.atom$// ? 1 : 0;
-  
-  my $rep_info = $is_wiki ? app->wiki_rep_info($user_id, $project_id) : app->rep_info($user_id, $project_id);
-  
+
+  my $rep_info = Gitprep::Repository->new($user_id, $project_id);
+  $rep_info = $rep_info->wiki if $is_wiki;
+
   my ($rev, $file) = $git->parse_rev_path($rep_info, $rev_file);
   my $page = param('page') || 1;
   

--- a/templates/compare.html.ep
+++ b/templates/compare.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   # API
   my $api = gitprep_api;
   
@@ -42,7 +44,7 @@
   )->one;
 
   # Base branches
-  my $base_rep_info = app->rep_info($base_user_id, $base_project_id);
+  my $base_rep_info = Gitprep::Repository->new($base_user_id, $base_project_id);
   my $base_branches = $git->branches($base_rep_info);
 
   # If no branch yet, redirect to project page which will display info
@@ -79,7 +81,7 @@
       )->one;
       $base_user_id = $original_project->{'user.id'};
       $base_project_id = $original_project->{'id'};
-      $base_branch = $git->current_branch(app->rep_info($base_user_id, $base_project_id));
+      $base_branch = $git->current_branch(Gitprep::Repository->new($base_user_id, $base_project_id));
       my $new_rev2 = new_rev2();
       $self->redirect_to("/$base_user_id/$base_project_id/compare/$base_branch...$new_rev2");
       return;
@@ -100,7 +102,7 @@
   my $bad_params = !$target_project;
 
   # Target branches
-  my $target_rep_info = app->rep_info($target_user_id, $target_project_id);
+  my $target_rep_info = Gitprep::Repository->new($target_user_id, $target_project_id);
   my $target_branches = [];
   $target_branches = $git->branches($target_rep_info) unless $bad_params;
 
@@ -232,7 +234,7 @@
   my $work_rep_info;
   if (!$bad_params) {
     # Lock working repository
-    $work_rep_info = app->work_rep_info($base_user_id, $base_project_id);
+    $work_rep_info = $base_rep_info->work;
     {
       my $lock_fh = $self->app->manager->lock_rep($work_rep_info);
 

--- a/templates/fork.html.ep
+++ b/templates/fork.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   # API
   my $api = gitprep_api;
 
@@ -7,7 +9,7 @@
   my $project_id = param('project');
   my $op = param('op');
 
-  my $rep_info = app->rep_info($user_id, $project_id);
+  my $rep_info = Gitprep::Repository->new($user_id, $project_id);
   my $rep = app->git->repository($rep_info);
 
   # Can fork?

--- a/templates/forks.html.ep
+++ b/templates/forks.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   # API.
   my $api = gitprep_api;
 
@@ -34,7 +36,7 @@
       )->all;
       $fork->{pr_count} = scalar(map $_->{pull_request}? 1: (), @$issues);
       $fork->{issue_count} = @$issues - $fork->{pr_count};
-      my $rep = app->git->repository(app->rep_info($fork->{'user.id'}, $fork->{id}));
+      my $rep = app->git->repository(Gitprep::Repository->new($fork->{'user.id'}, $fork->{id}));
       unless ($rep->{updated} && $fork->{created} && $rep->{updated} < $fork->{created}) {
         $fork->{updated} = $rep->{updated};
       }

--- a/templates/include/blob_diff_body.html.ep
+++ b/templates/include/blob_diff_body.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   my $api = gitprep_api;
 
   my $user_id = stash('user');
@@ -11,7 +13,8 @@
   if ($is_wiki) {
     $user_project_path .= '/wiki';
   }
-  my $rep_info = $is_wiki ? app->wiki_rep_info($user_id, $project_id) : app->rep_info($user_id, $project_id);
+  my $rep_info = Gitprep::Repository->new($user_id, $project_id);
+  $rep_info = $rep_info->wiki if $is_wiki;
 
   my $git = app->git;
   

--- a/templates/include/branch_select.html.ep
+++ b/templates/include/branch_select.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   my $api = gitprep_api;
   
   my $user = param('user');
@@ -16,7 +18,7 @@
   
   my $path = stash('Path');
 
-  my $rep_info = app->rep_info($user, $project);
+  my $rep_info = Gitprep::Repository->new($user, $project);
   my $tags = app->git->tags($rep_info);
   my $rev_short;
   my $active_branch = 'active';

--- a/templates/include/commit_body.html.ep
+++ b/templates/include/commit_body.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   # Parameters
   my $user_id = stash('user');
   my $project_id = stash('project');
@@ -13,7 +15,8 @@
   }
   
   unless ($rep_info) {
-    $rep_info = $is_wiki ? app->wiki_rep_info($user_id, $project_id) : app->rep_info($user_id, $project_id);
+    $rep_info = Gitprep::Repository->new($user_id, $project_id);
+    $rep_info = $rep_info->wiki if $is_wiki;
   }
   
   my $param_ignore_space_change = param('w');

--- a/templates/include/commit_summary.html.ep
+++ b/templates/include/commit_summary.html.ep
@@ -11,7 +11,7 @@
   my $file = stash('rep_file') // '';
   my $history = stash('history') // 'History';
 
-  my $url = $rep_info->{url};
+  my $url = $rep_info->url;
 
   my $commit;
   if (!$git->rev_exists($rep_info, $rev) || !($commit = $git->last_change_commits($rep_info, $rev, [$file])->{$file})) {

--- a/templates/include/readme.html.ep
+++ b/templates/include/readme.html.ep
@@ -1,5 +1,6 @@
 <%
   use Mojo::ByteStream ();
+  use Gitprep::Repository;
 
   my $api = gitprep_api;
 
@@ -77,7 +78,7 @@
     }}
   );
 
-  my $rep_info = app->rep_info($user, $project);
+  my $rep_info = Gitprep::Repository->new($user, $project);
   my %filecache;
 
   foreach my $docdir (reverse @docdirs) {

--- a/templates/include/tree.html.ep
+++ b/templates/include/tree.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   # API
   my $api = gitprep_api;
   
@@ -16,7 +18,7 @@
   my $project_id = stash('project_id');
   my $rev = stash('rev');
 
-  my $rep_info = app->rep_info($user_id, $project_id);
+  my $rep_info = Gitprep::Repository->new($user_id, $project_id);
   my $default_branch_name = $git->current_branch($rep_info);
   
   my $history;

--- a/templates/issue.html.ep
+++ b/templates/issue.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   # API
   my $api = gitprep_api;
 
@@ -309,13 +311,15 @@
     $target_project_id = $target_project->{id};
 
     # Base repository information
-    my $base_rep_info = app->rep_info($base_user_id, $base_project_id);
+    my $base_rep_info = Gitprep::Repository->new($base_user_id,
+      $base_project_id);
 
     # Target repository information
-    my $target_rep_info = app->rep_info($target_user_id, $target_project_id);
+    my $target_rep_info = Gitprep::Repository->new($target_user_id,
+      $target_project_id);
 
     # Working repository information
-    my $work_rep_info = app->work_rep_info($base_user_id, $base_project_id);
+    my $work_rep_info = $base_rep_info->work;
 
     # Make sure the working repository exists.
     app->manager->create_work_rep($base_user_id, $base_project_id);

--- a/templates/issues.html.ep
+++ b/templates/issues.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   # API
   my $api = gitprep_api;
 
@@ -65,7 +67,7 @@
     {pull => $pulls}) - $open_count;
 
   # Default branch
-  my $default_branch = app->git->current_branch(app->rep_info($user_id, $project_id));
+  my $default_branch = app->git->current_branch(Gitprep::Repository->new($user_id, $project_id));
 
   # Original project
   my $original_project = app->manager->original_project($user_id, $project_id);
@@ -117,7 +119,7 @@
           % if (!$pulls) {
             <a href="<%= url_for("/$user_id/$project_id/issues/new") %>" class="btn btn-green btn-new">New issue</a>
           % } elsif ($original_project) {
-            % my $original_default_branch = app->git->current_branch(app->rep_info($original_project->{'user.id'}, $original_project->{id}));
+            % my $original_default_branch = app->git->current_branch(Gitprep::Repository->new($original_project->{'user.id'}, $original_project->{id}));
             <a href="<%= url_for("/$original_project->{'user.id'}/$original_project->{id}/compare/$original_default_branch...$user_id:$project_id:$default_branch") %>" class="btn btn-green btn-new">New pull request</a>
           % } else {
             <a href="<%= url_for("/$user_id/$project_id/compare") %>" class="btn btn-green btn-new">New pull request</a>

--- a/templates/layouts/common.html.ep
+++ b/templates/layouts/common.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   my $stylesheets = stash('stylesheets') || [];
   my $user = stash('user');
   $user = '' unless defined $user;
@@ -6,7 +8,7 @@
   $project = '' unless defined $project;
   my $rev = stash('rev');
   if (length $user && length $project && !defined $rev) {
-    $rev = app->git->current_branch(app->rep_info($user, $project));
+    $rev = app->git->current_branch(Gitprep::Repository->new($user, $project));
   }
   $rev = '' unless $rev;
 %>

--- a/templates/network.html.ep
+++ b/templates/network.html.ep
@@ -1,11 +1,13 @@
 <%
+  use Gitprep::Repository;
+
   # API
   my $api = gitprep_api;
   
   my $user_id = param('user');
   my $project_id = param('project');
-  
-  my $rep_info = $self->app->rep_info($user_id, $project_id);
+
+  my $rep_info = Gitprep::Repository->new($user_id, $project_id);
   
   # Branches
   my $branches = [map { $_->{name} } @{app->git->branches($rep_info)}];
@@ -42,7 +44,7 @@
   
   # Members branches
   for my $member_project (@$member_projects) {
-    my $member_rep_info = $self->app->rep_info($member_project->{'user.id'}, $member_project->{id});
+    my $member_rep_info = Gitprep::Repository->new($member_project->{'user.id'}, $member_project->{id});
     
     my $branches = app->git->branches($member_rep_info);
     $branches = [map { $_->{name} } @$branches];

--- a/templates/network/graph.html.ep
+++ b/templates/network/graph.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   # API
   my $api = gitprep_api;
 
@@ -9,12 +11,10 @@
   my $rev2_abs = param('rev2_abs');
   my ($remote_user, $remote_project, $remote_branch) = split /\//, $rev2_abs, 3;
   
-  my $commits = app->git->get_commits(app->rep_info($user, $project), $branch, 100);
-  my $remote_commits = app->git->get_commits(
-    app->rep_info($remote_user, $remote_project),
-    $remote_branch,
-    100
-  );
+  my $commits = app->git->get_commits(Gitprep::Repository->new($user, $project),
+    $branch, 100);
+  my $remote_commits = app->git->get_commits(Gitprep::Repository->new($remote_user,
+    $remote_project), $remote_branch, 100);
   
   my $merged_commits_h = {};
   for my $commit (@$commits) {

--- a/templates/raw.html.ep
+++ b/templates/raw.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   # Git
   my $git = app->git;
 
@@ -12,7 +14,8 @@
   if ($is_wiki) {
     $user_id_project_path .= '/wiki';
   }
-  my $rep_info = $is_wiki ? app->wiki_rep_info($user_id, $project_id) : app->rep_info($user_id, $project_id);
+  my $rep_info = Gitprep::Repository->new($user_id, $project_id);
+  $rep_info = $rep_info->wiki if $is_wiki;
 
   my ($rev, $file) = $git->parse_rev_path($rep_info, $rev_file);
   

--- a/templates/settings.html.ep
+++ b/templates/settings.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   # API
   my $api = gitprep_api;
   my $manager = app->manager;
@@ -16,7 +18,7 @@
     return;
   }
 
-  my $rep_info = app->rep_info($user_id, $project_id);
+  my $rep_info = Gitprep::Repository->new($user_id, $project_id);
   my $current_branch = $git->current_branch($rep_info);
 
   # Rename project

--- a/templates/settings/rulesets.html.ep
+++ b/templates/settings/rulesets.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   # API
   my $api = gitprep_api;
   my $manager = app->manager;
@@ -32,7 +34,7 @@
   }
 
   my $rules = $manager->rules;
-  my $rep_info = app->rep_info($user_id, $project_id);
+  my $rep_info = Gitprep::Repository->new($user_id, $project_id);
   my $refs;
   if ($target eq 'branch') {
     $refs = $git->branch_names($rep_info);

--- a/templates/smart-http/info-refs.html.ep
+++ b/templates/smart-http/info-refs.html.ep
@@ -2,6 +2,7 @@
   use IPC::Open3 ();;
   use Symbol ();
   use IO::Select ();
+  use Gitprep::Repository;
   
   my $service = param('service') || '';
   my $user = param('user');
@@ -10,15 +11,21 @@
   
   my $auth_user_id = stash('auth_user_id') // '';
 
+  my $rep_info = Gitprep::Repository->new($user, $project);
+
   # Smart HTTP
   if ($service eq 'git-upload-pack' || $service eq 'git-receive-pack') {
     
     my $service_cmd = $service;
     substr($service_cmd, 0, 4, '');
     
-    my $rep_info = app->rep_info($user, $project);
-    my $rep_git_dir = $rep_info->{git_dir};
-    my @cmd = $git->cmd($rep_info, $service_cmd, '--stateless-rpc', '--advertise-refs', $rep_git_dir);
+    my @cmd = $git->cmd(
+      $rep_info,
+      $service_cmd,
+      '--stateless-rpc',
+      '--advertise-refs',
+      $rep_info->git_dir
+    );
     
     my %save_env = %ENV;
     app->manager->prepare_hooks($auth_user_id, $rep_info);
@@ -64,16 +71,14 @@
   # Dumb HTTP
   else {
     # Update server info
-    my @cmd = $git->cmd(app->rep_info($user, $project), 'update-server-info');
+    my @cmd = $git->cmd($rep_info, 'update-server-info');
     open my $fh, '-|', @cmd
       or die "Can't open pipe for @cmd:$!";
     close $fh
       or die "Can't close pipe for @cmd:$!";
     
     my $content_type = 'text/plain; charset=UTF-8';
-    my $rep_info = app->rep_info($user, $project);
-    my $rep_git_dir = $rep_info->{git_dir};
-    my $file = "$rep_git_dir/info/refs";
+    my $file = $rep_info->git_dir('info/refs');
     if (-f $file) {
       my $asset = Mojo::Asset::File->new(path => $file);
       my $content = $asset->slurp;

--- a/templates/smart-http/service.html.ep
+++ b/templates/smart-http/service.html.ep
@@ -2,6 +2,7 @@
   use IPC::Open3 ();
   use Symbol ();
   use IO::Select ();
+  use Gitprep::Repository;
   
   my $service = param('service');
   my $user = param('user');
@@ -11,9 +12,13 @@
 
   my $auth_user_id = stash('auth_user_id') // '';
 
-  my $rep_info = app->rep_info($user, $project);
-  my $rep_git_dir = $rep_info->{git_dir};
-  my @cmd = $git->cmd(app->rep_info($user, $project), $service, '--stateless-rpc', $rep_git_dir);
+  my $rep_info = Gitprep::Repository->new($user, $project);
+  my @cmd = $git->cmd(
+    $rep_info,
+    $service,
+    '--stateless-rpc',
+    $rep_info->git_dir
+  );
   my %save_env = %ENV;
   app->manager->prepare_hooks($auth_user_id, $rep_info);
   

--- a/templates/smart-http/static.html.ep
+++ b/templates/smart-http/static.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   my $path = param('Path');
   my $user = param('user');
   my $project = param('project');
@@ -31,9 +33,8 @@
     $content_type = 'application/x-git-packed-objects-toc';
   }
   
-  my $rep_info = app->rep_info($user, $project);
-  my $rep_git_dir = $rep_info->{git_dir};
-  my $file = "$rep_git_dir/$path";
+  my $rep_info = Gitprep::Repository->new($user, $project);
+  my $file = $rep_info->git_dir($path);
   if (-f $file) {
     my $asset = Mojo::Asset::File->new(path => $file);
     my $content = $asset->slurp;

--- a/templates/submodule.html.ep
+++ b/templates/submodule.html.ep
@@ -1,5 +1,6 @@
 <%
   use File::Basename ();
+  use Gitprep::Repository;
   
   # API
   my $api = gitprep_api;
@@ -11,11 +12,12 @@
   my $user = param('user');
   my $project = param('project');
   my $rev_file = param('rev_file');
-  my ($rev, $file) = $git->parse_rev_path(app->rep_info($user, $project), $rev_file);
+  my $rep_info = Gitprep::Repository->new($user, $project);
+  my ($rev, $file) = $git->parse_rev_path($rep_info, $rev_file);
   my $file_base = File::Basename::basename $file;
 
   # Blob lines
-  my $lines = $git->blob(app->rep_info($user, $project), $rev, '.gitmodules');
+  my $lines = $git->blob($rep_info, $rev, '.gitmodules');
   
   my $submodule_rep_url;
   my $match;

--- a/templates/tags.html.ep
+++ b/templates/tags.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   # API
   my $api = Gitprep::API->new($self);
 
@@ -9,17 +11,19 @@
   
   # Git
   my $git = $self->app->git;
-  
+
+  my $rep_info = Gitprep::Repository->new($user, $project);
+
   # Ref names
   my $limit = app->config->{basic}{tags_limit};
   my $page_count = 20;
   my $tags = $git->tags(
-    app->rep_info($user, $project),
+    $rep_info,
     $limit,
     $page_count,
     $page_count * ($page - 1)
   );
-  my $tags_count = $git->tags_count(app->rep_info($user, $project));
+  my $tags_count = $git->tags_count($rep_info);
 %>
 
 % layout 'common', title => "Tags \x{b7} $user/$project";

--- a/templates/tree.html.ep
+++ b/templates/tree.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   my $state;
 
   # API
@@ -12,7 +14,7 @@
   my $project_id = param('project');
   
   my $project_row_id = $api->get_project_row_id($user_id, $project_id);
-  my $rep_info = app->rep_info($user_id, $project_id);
+  my $rep_info = Gitprep::Repository->new($user_id, $project_id);
   my $default_branch = $git->current_branch($rep_info);
   
   my $rev;

--- a/templates/user.html.ep
+++ b/templates/user.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   use Mojo::JSON qw(decode_json);
   use Mojo::ByteStream;
 
@@ -25,7 +27,7 @@
   my $projects = app->manager->projects($user_id);
   my $reps = [];
   for my $project (@$projects) {
-    my $rep = app->git->repository(app->rep_info($user_id, $project->{id})) || {none => 1};
+    my $rep = app->git->repository(Gitprep::Repository->new($user_id, $project->{id})) || {none => 1};
     $rep->{id} = $project->{id};
     $rep->{private} = $project->{private};
     push @$reps, $rep;

--- a/templates/wiki.html.ep
+++ b/templates/wiki.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Repository;
+
   # API
   my $api = gitprep_api;
 
@@ -128,7 +130,7 @@
   else {
     if ($wiki) {
       $pages_count = $api->get_wiki_pages_count($user_id, $project_id);
-      $commits_number = app->git->commits_number(app->wiki_rep_info($user_id, $project_id), 'master');
+      $commits_number = app->git->commits_number(Gitprep::Repository::Wiki->new($user_id, $project_id), 'master');
       
       if ($edit) {
         $content = $api->get_wiki_page_content($user_id, $project_id, $title);


### PR DESCRIPTION
Turning various rep_infos from hashes to objects eases adding new methods/values to them and allows more dynamic handling.

A new module lib/Gitprep/Info.pm implements the classes.

A test t/rep_info.t for these classes is added.

The existing code is adapted to use rep_info objects and take advantages of this new situation.