### PR TITLE
Support slashes and initial period in wiki titles

### DIFF
--- a/lib/Gitprep.pm
+++ b/lib/Gitprep.pm
@@ -598,12 +598,6 @@ sub startup {
               # Show pages
               $r->any('/_pages')->to('list-pages' => 1);
 
-              # Show wiki page
-              $r->any('/:title');
-
-              # Edit wiki page
-              $r->any('/:title/_edit')->to(edit => 1);
-
               # Commits
               $r->get('/commits/*rev_file' => sub { shift->render_maybe('/commits') });
 
@@ -624,6 +618,12 @@ sub startup {
 
               # Diff folding
               $r->post('/api/fold/*rev_file' => sub { shift->render_maybe('/api/diff_fold'); });
+
+              # Edit wiki page
+              $r->any('/*title/_edit')->to(edit => 1);
+
+              # Show wiki page
+              $r->any('/*title');
             }
 
             # Commit

--- a/lib/Gitprep/API.pm
+++ b/lib/Gitprep/API.pm
@@ -55,9 +55,12 @@ sub sync_wiki_work {
     $wiki_rep_info->project) unless -d $wiki_work_rep_info->root;
 
   if (-f $wiki_rep_info->git_dir('refs/heads/master')) {
+    $self->app->manager->set_remote($wiki_work_rep_info,
+                                    'origin', $wiki_rep_info);
     my @git_pull_cmd = $self->app->git->cmd(
       $wiki_work_rep_info,
-      'pull'
+      'pull',
+      $wiki_rep_info->git_dir
     );
 
     Gitprep::Util::run_command(@git_pull_cmd)
@@ -224,6 +227,8 @@ sub create_wiki_page {
   Gitprep::Util::run_command(@git_commit_cmd)
     or croak "Can't execute git commit: @git_commit_cmd";
 
+  $self->app->manager->set_remote($wiki_work_rep_info, 'origin', $wiki_rep_info);
+
   # Push
   {
     my @git_push_cmd = $self->app->git->cmd(
@@ -329,6 +334,8 @@ sub rename_and_update_wiki_page {
   Gitprep::Util::run_command(@git_commit_cmd)
     or croak "Can't execute git commit: @git_commit_cmd";
 
+  $self->app->manager->set_remote($wiki_work_rep_info, 'origin', $wiki_rep_info);
+
   # Push
   {
     my @git_push_cmd = $self->app->git->cmd(
@@ -406,6 +413,8 @@ sub delete_wiki_page {
   );
   Gitprep::Util::run_command(@git_commit_cmd)
     or croak "Can't execute git commit: @git_commit_cmd";
+
+  $self->app->manager->set_remote($wiki_work_rep_info, 'origin', $wiki_rep_info);
 
   # Push
   {

--- a/lib/Gitprep/API.pm
+++ b/lib/Gitprep/API.pm
@@ -65,6 +65,25 @@ sub sync_wiki_work {
   }
 }
 
+sub wiki_title_to_name {
+  my ($self, $title) = @_;
+
+  $title =~ s/^\s*(.*?)\s*$/$1/;           # Trim.
+  $title =~ s/^\./\x{2024}/;               # No hidden page: use one dot leader.
+  $title =~ s#/#\x{2215}#g;                # Use division slashes.
+  return "$title.md";
+}
+
+sub wiki_name_to_title {
+  my ($self, $name) = @_;
+
+  return unless $name =~ /^(.*)\.md$/;
+  $name = $1;
+  $name =~ s/^\x{2024}/./;
+  $name =~ s#\x{2215}#/#g;
+  return $name;
+}
+
 sub exists_wiki_page {
   my ($self, $user_id, $project_id, $title) = @_;
 
@@ -72,17 +91,12 @@ sub exists_wiki_page {
     $project_id)->work;
 
   # File name
-  my $file_name = $title;
-  $file_name =~ s/^ +//;
-  $file_name =~ s/ +$//;
-  $file_name .= '.md';
+  my $file_name = $self->wiki_title_to_name($title);
 
   # File abs name
   my $file_abs_name = $wiki_work_rep_info->work_tree($file_name);
 
-  my $exists = -f encode('UTF-8', $file_abs_name);
-
-  return $exists;
+  return -f encode('UTF-8', $file_abs_name);
 }
 
 sub get_wiki_pages {
@@ -101,36 +115,14 @@ sub get_wiki_pages {
   while (my $file = readdir $dh) {
     $file = decode('UTF-8', $file);
     next if $file =~ /^\./;
-    $file =~ s/\.[^\.]+$//;
-    push @pages, $file;
+    my $abs_file = encode('UTF-8', $wiki_work_rep_info->work_tree($file));
+    next unless -f $abs_file;
+    my $t = $self->wiki_name_to_title($file);
+    push @pages, $t if defined $t && $self->wiki_title_to_name($t) eq $file;
   }
 
   @pages = sort { lc $a cmp lc $b } @pages;
-
   return \@pages;
-}
-
-sub get_wiki_pages_count {
-  my ($self, $user_id, $project_id) = @_;
-
-  my $wiki_work_rep_info = Gitprep::Repository::Wiki->new($user_id,
-    $project_id)->work;
-
-  # Open directory
-  my $dir = $wiki_work_rep_info->work_tree;
-  opendir my $dh, $dir
-    or croak "Can't open directory \"$dir\":$!";
-
-  # Pages
-  my $count = 0;
-  while (my $file = readdir $dh) {
-    $file = decode('UTF-8', $file);
-    next if $file =~ /^\./;
-    $file =~ s/\.[^\.]+$//;
-    $count++;
-  }
-
-  return $count;
 }
 
 sub get_wiki_page_content {
@@ -140,20 +132,16 @@ sub get_wiki_page_content {
     $project_id)->work;
 
   # File name
-  my $file_name = $title;
-  $file_name =~ s/^ +//;
-  $file_name =~ s/ +$//;
-  $file_name .= '.md';
+  my $file_name = $self->wiki_title_to_name($title);
 
   # File abs name
   my $file_abs_name = $wiki_work_rep_info->work_tree($file_name);
 
-  unless (-f encode('UTF-8', $file_abs_name)) {
-    return;
-  }
+  my $utf8_name = encode('UTF-8', $file_abs_name);
+  return unless -f $utf8_name;
 
-  open my $fh, '<', encode('UTF-8', $file_abs_name)
-    or die "Can't open file \"" . encode('UTF-8', $file_abs_name) . "\": $!";
+  open my $fh, '<', $utf8_name
+    or die "Can't open file \"$utf8_name\": $!";
 
   my $content = do { local $/; <$fh> };
 
@@ -177,16 +165,14 @@ sub create_wiki_page {
   my $wiki_work_rep_info = $wiki_rep_info->work;
 
   # File name
-  my $file_name = $title;
-  $file_name =~ s/^ +//;
-  $file_name =~ s/ +$//;
-  $file_name .= '.md';
+  my $file_name = $self->wiki_title_to_name($title);
 
   # File abs name
   my $file_abs_name = $wiki_work_rep_info->work_tree($file_name);
+  my $utf8_name = encode('UTF-8', $file_abs_name);
 
-  open my $fh, '>:encoding(UTF-8)', encode('UTF-8', $file_abs_name)
-    or die "Can't open file \"". encode('UTF-8', $file_abs_name) . "\": $!";
+  open my $fh, '>:encoding(UTF-8)', $utf8_name
+    or die "Can't open file \"$utf8_name\": $!";
 
   # Write content to file
   print $fh $content;
@@ -260,26 +246,21 @@ sub rename_and_update_wiki_page {
   my $wiki_work_rep_info = $wiki_rep_info->work;
 
   # Original file name
-  my $original_file_name = $original_title;
-  $original_file_name =~ s/^ +//;
-  $original_file_name =~ s/ +$//;
-  $original_file_name .= '.md';
+  my $original_file_name = $self->wiki_title_to_name($original_title);
 
   # File name
-  my $file_name = $title;
-  $file_name =~ s/^ +//;
-  $file_name =~ s/ +$//;
-  $file_name .= '.md';
+  my $file_name = $self->wiki_title_to_name($title);
 
   # Original file abs name
   my $original_file_abs_name = $wiki_work_rep_info->work_tree($original_file_name);
 
   # File abs name
   my $file_abs_name = $wiki_work_rep_info->work_tree($file_name);
+  my $utf8_name = encode('UTF-8', $file_abs_name);
 
   # Create file
-  open my $fh, '>:encoding(UTF-8)', encode('UTF-8', $file_abs_name)
-    or die "Can't open file \"". encode('UTF-8', $file_abs_name) . "\": $!";
+  open my $fh, '>:encoding(UTF-8)', $utf8_name
+    or die "Can't open file \"$utf8_name\": $!";
 
   # Write content to file
   print $fh $content;
@@ -288,9 +269,10 @@ sub rename_and_update_wiki_page {
   close $fh;
 
   # Delete original file
-  if (-f encode('UTF-8', $original_file_abs_name)) {
-    unlink encode('UTF-8', $original_file_abs_name)
-      or die "Can't delete file \"" . encode('UTF-8', $original_file_abs_name) . "\": $!";
+  my $utf8_original_name = encode('UTF-8', $original_file_abs_name);
+  if (-f $utf8_original_name) {
+    unlink $utf8_original_name
+      or die "Can't delete file \"$utf8_original_name\": $!";
   }
 
   # Check file changes
@@ -316,7 +298,7 @@ sub rename_and_update_wiki_page {
   my @git_rm_cmd = $self->app->git->cmd(
     $wiki_work_rep_info,
     'rm',
-    encode('UTF-8', $original_file_abs_name)
+    $utf8_original_name
   );
 
   Gitprep::Util::run_command(@git_rm_cmd)
@@ -368,16 +350,16 @@ sub delete_wiki_page {
   my $wiki_work_rep_info = $wiki_rep_info->work;
 
   # File name
-  my $file_name = $title;
-  $file_name .= '.md';
+  my $file_name = $self->wiki_title_to_name($title);
 
   # File abs name
   my $file_abs_name = $wiki_work_rep_info->work_tree($file_name);
+  my $utf8_name = encode('UTF-8', $file_abs_name);
 
   # Delete file
-  if (-f encode('UTF-8', $file_abs_name)) {
-    unlink encode('UTF-8', $file_abs_name)
-      or die "Can't delete file \"" . encode('UTF-8', $file_abs_name) . "\": $!";
+  if (-f $utf8_name) {
+    unlink $utf8_name
+      or die "Can't delete file \"$utf8_name\": $!";
   }
 
   # Check file changes
@@ -403,7 +385,7 @@ sub delete_wiki_page {
   my @git_rm_cmd = $self->app->git->cmd(
     $wiki_work_rep_info,
     'rm',
-    encode('UTF-8', $file_abs_name)
+    $utf8_name
   );
 
   Gitprep::Util::run_command(@git_rm_cmd)

--- a/lib/Gitprep/API.pm
+++ b/lib/Gitprep/API.pm
@@ -68,7 +68,7 @@ sub sync_wiki_work {
 sub wiki_title_to_name {
   my ($self, $title) = @_;
 
-  $title =~ s/^\s*(.*?)\s*$/$1/;           # Trim.
+  $title =~ s/^(.*?)\s*$/$1/;              # Trim right.
   $title =~ s/^\./\x{2024}/;               # No hidden page: use one dot leader.
   $title =~ s#/#\x{2215}#g;                # Use division slashes.
   return "$title.md";
@@ -84,19 +84,23 @@ sub wiki_name_to_title {
   return $name;
 }
 
-sub exists_wiki_page {
-  my ($self, $user_id, $project_id, $title) = @_;
+sub wiki_file_exists {
+  my ($self, $user_id, $project_id, $file_name) = @_;
 
   my $wiki_work_rep_info = Gitprep::Repository::Wiki->new($user_id,
     $project_id)->work;
-
-  # File name
-  my $file_name = $self->wiki_title_to_name($title);
 
   # File abs name
   my $file_abs_name = $wiki_work_rep_info->work_tree($file_name);
 
   return -f encode('UTF-8', $file_abs_name);
+}
+
+sub exists_wiki_page {
+  my ($self, $user_id, $project_id, $title) = @_;
+
+  return $self->wiki_file_exists($user_id, $project_id,
+   $self->wiki_title_to_name($title));
 }
 
 sub get_wiki_pages {

--- a/lib/Gitprep/Git.pm
+++ b/lib/Gitprep/Git.pm
@@ -1506,23 +1506,6 @@ sub locate_commit {
   return \@lines;
 }
 
-sub import_branch {
-  my ($self, $rep_info, $branch, $remote_rep_info, $remote_branch, $opt) = @_;
-
-  my $force = $opt->{force};
-
-  # Git pull
-  my @cmd = $self->cmd(
-    $rep_info,
-    'fetch',
-    $remote_rep_info->git_dir,
-    ($force ? '+' : '') . "refs/heads/$remote_branch:refs/heads/$branch"
-  );
-
-  Gitprep::Util::run_command(@cmd)
-    or croak 'Open git fetch for import_branch failed';
-}
-
 sub search_bin {
   my $self = shift;
 

--- a/lib/Gitprep/Git.pm
+++ b/lib/Gitprep/Git.pm
@@ -601,7 +601,7 @@ sub blob_size {
 sub check_head_link {
   my ($self, $dir) = @_;
 
-  # Chack head
+  # Check head
   my $head_file = "$dir/HEAD";
   return ((-e $head_file) ||
     (-l $head_file && readlink($head_file) =~ /^refs\/heads\//));
@@ -965,13 +965,12 @@ sub parse_rev_path {
     }
   }
 
-  if ($rev_path) {
-    my ($rev, $path) = split /\//, $rev_path, 2;
-    $path = '' unless defined $path;
-    return ($rev, $path);
-  }
+  my ($rev, $path) = split /\//, $rev_path, 2;
+  $path //= '';
+  ($rev, $path) = ($self->current_branch($rep_info), $rev_path)
+    unless $rev =~ /^[0-9a-fA-F]{7,40}$/;
 
-  return;
+  return ($rev, $path);
 }
 
 sub object_type {

--- a/lib/Gitprep/Manager.pm
+++ b/lib/Gitprep/Manager.pm
@@ -32,6 +32,22 @@ sub get_remotes {
   return \%remotes;
 }
 
+# Make sure remote exists and points to the target repository.
+sub set_remote {
+  my ($self, $work_rep_info, $name, $target_rep_info) = @_;
+  my $remotes = $self->get_remotes($work_rep_info);
+  if (($remotes->{$name} // '') ne $target_rep_info->git_dir) {
+    my @git_remote_cmd = $self->app->git->cmd($work_rep_info,
+      'remote',
+      exists($remotes->{$name})? 'set-url': 'add',
+      $name,
+      $target_rep_info->git_dir
+    );
+    Gitprep::Util::run_command(@git_remote_cmd)
+      or Carp::croak "Can't execute git remote @git_remote_cmd";
+  }
+}
+
 sub prepare_merge {
   my ($self, $work_rep_info, $base_rep_info, $base_branch, $target_rep_info, $target_branch) = @_;
 
@@ -39,24 +55,14 @@ sub prepare_merge {
 
   # Fetch base repository
   my $base_user_id = $base_rep_info->user;
+  $self->set_remote($work_rep_info, 'origin', $base_rep_info);
   my @git_fetch_base_cmd = $git->cmd($work_rep_info, 'fetch', 'origin');
   Gitprep::Util::run_command(@git_fetch_base_cmd)
     or Carp::croak "Can't execute git fetch: @git_fetch_base_cmd";
 
   # Configure remote for target repository
   my $target_remote = $target_rep_info->remote_name;
-  my $remotes = $self->get_remotes($work_rep_info);
-  if (exists $remotes->{$target_remote} && $remotes->{$target_remote} ne $target_rep_info->root) {
-    my @git_remote_remove_cmd = $git->cmd($work_rep_info, 'remote', 'remove', $target_remote);
-    Gitprep::Util::run_command(@git_remote_remove_cmd)
-      or Carp::croak "Can't execute git remote @git_remote_remove_cmd";
-    delete $remotes->{$target_remote};
-  }
-  if (!exists $remotes->{$target_remote}) {
-    my @git_remote_add_cmd = $git->cmd($work_rep_info, 'remote', 'add', $target_remote, $target_rep_info->root);
-    Gitprep::Util::run_command(@git_remote_add_cmd)
-      or Carp::croak "Can't execute git remote @git_remote_add_cmd";
-  }
+  $self->set_remote($work_rep_info, $target_remote, $target_rep_info);
 
   # Fetch target repository
   my @git_fetch_target_cmd = $git->cmd($work_rep_info, 'fetch', $target_remote);
@@ -184,6 +190,8 @@ sub merge_base {
 
 sub push {
   my ($self, $work_rep_info, $base_branch) = @_;
+
+  $self->set_remote($work_rep_info, 'origin', $work_rep_info->repo);
 
   # Push
   my $tmp_branch = $self->_tmp_branch;

--- a/lib/Gitprep/Repository.pm
+++ b/lib/Gitprep/Repository.pm
@@ -1,5 +1,8 @@
 package Gitprep::Repository;
 
+use strict;
+use warnings;
+
 use Gitprep::Repository::Wiki;
 use Gitprep::Repository::Work;
 
@@ -72,7 +75,10 @@ sub remote_name {
 }
 
 # Return a bare repository matching the object, whatever variant is the latter.
-sub repo { return Gitprep::Repository->new($self->user, $self->project); }
+sub repo {
+  my $self = shift;
+  return Gitprep::Repository->new($self->user, $self->project);
+}
 
 # Return a wiki repository matching the object, whatever variant is the latter.
 sub wiki {

--- a/lib/Gitprep/Repository.pm
+++ b/lib/Gitprep/Repository.pm
@@ -54,7 +54,9 @@ sub root {
   my ($self, $file) = @_;
   my $home = $self->home;
   my $wiki = $self->_project_suffix;
-  return $self->_path("$home/$self->{user}/$self->{project}$wiki.git", $file);
+  my $path = "$home/$self->{user}/$self->{project}$wiki.git";
+  $path = "$path/$file" if defined $file;
+  return $path;
 }
 
 # Return the repository's directory where git support files are located.
@@ -64,7 +66,9 @@ sub git_dir { return shift->root(@_); }
 sub url {
   my ($self, $file) = @_;
   my $wiki = $self->_url_suffix;
-  return $self->_path("/$self->{user}/$self->{project}$wiki", $file);
+  my $path = "/$self->{user}/$self->{project}$wiki";
+  $path = "$path/$file" if defined $file;
+  return $path;
 }
 
 # Return a suitable unambiguous name for an upstream repository.
@@ -98,16 +102,6 @@ sub maybe_wiki {
     $rep_info = Gitprep::Repository::Wiki->new($rep_info->user, $1) if $2;
   }
   return $rep_info;
-}
-
-# Protected method to cleanly concatenate paths.
-sub _path {
-  my ($self, $path, $file) = @_;
-  $file //= '';
-  $file =~ s#^/*(.*?)/*$#$1#;
-  $file =~ s#/+$#/#g;
-  $path .= "/$file" if $file ne '';
-  return $path;
 }
 
 

--- a/lib/Gitprep/Repository/Wiki.pm
+++ b/lib/Gitprep/Repository/Wiki.pm
@@ -1,6 +1,9 @@
 package Gitprep::Repository::Wiki;
 
-use parent Gitprep::Repository;
+use strict;
+use warnings;
+
+use parent qw(Gitprep::Repository);
 
 use constant _project_suffix => '.wiki';
 use constant _url_suffix => '/wiki';

--- a/lib/Gitprep/Repository/Work.pm
+++ b/lib/Gitprep/Repository/Work.pm
@@ -52,13 +52,17 @@ sub root {
   my $user = $origin->user;
   my $project = $origin->project;
   my $is_wiki = $origin->_project_suffix;
-  return $origin->_path("$home/$user/$project$is_wiki", $file);
+  my $path = "$home/$user/$project$is_wiki";
+  $path = "$path/$file" if defined $file;
+  return $path;
 }
 
 sub git_dir {
   my ($self, $file) = @_;
   my $root = $self->root;
-  return $self->origin->_path("$root/.git", $file);
+  my $path = "$root/.git";
+  $path = "$path/$file" if defined $file;
+  return $path;
 }
 
 # Return the top level directory for the project files.

--- a/lib/Gitprep/Repository/Work.pm
+++ b/lib/Gitprep/Repository/Work.pm
@@ -1,5 +1,8 @@
 package Gitprep::Repository::Work;
 
+use strict;
+use warnings;
+
 use Gitprep::Repository;
 
 my $home;

--- a/templates/raw.html.ep
+++ b/templates/raw.html.ep
@@ -10,10 +10,6 @@
   my $rev_file = param('rev_file');
 
   my $is_wiki = (stash('tab') // '') eq 'wiki';
-  my $user_id_project_path = "/$user_id/$project_id";
-  if ($is_wiki) {
-    $user_id_project_path .= '/wiki';
-  }
   my $rep_info = Gitprep::Repository->new($user_id, $project_id);
   $rep_info = $rep_info->wiki if $is_wiki;
 

--- a/templates/wiki.html.ep
+++ b/templates/wiki.html.ep
@@ -21,10 +21,11 @@
   my $wiki_rep_info = Gitprep::Repository::Wiki->new($user_id, $project_id);
   my $wiki = -d $wiki_rep_info->root;
   $api->sync_wiki_work($wiki_rep_info) if $wiki;
+  my $pages = [];
+  $pages = $api->get_wiki_pages($user_id, $project_id) if $wiki;
 
   my $content;
   my $content_md;
-  my $pages;
 
   # Session
   my $logined = $api->logined;
@@ -118,7 +119,7 @@
   my $content_footer_md;
 
   # Pages count
-  my $pages_count = 0;
+  my $pages_count = @$pages;
 
   # Commits number
   my $commits_number = 0;
@@ -131,7 +132,6 @@
   }
   else {
     if ($wiki) {
-      $pages_count = $api->get_wiki_pages_count($user_id, $project_id);
       $commits_number = app->git->commits_number($wiki_rep_info, 'master');
 
       if ($edit) {
@@ -145,8 +145,6 @@
       }
       elsif ($list_pages) {
         $display = 'list-pages';
-        # Pages
-        $pages = $api->get_wiki_pages($user_id, $project_id);
       }
       else {
         if (($title // '') eq 'Home') {

--- a/templates/wiki.html.ep
+++ b/templates/wiki.html.ep
@@ -103,7 +103,7 @@
             $api->create_wiki_page($user_id, $project_id, $update_title, $content, $commit_message);
           }
 
-          $self->redirect_to("/$user_id/$project_id/wiki/$update_title");
+          $self->redirect_to($wiki_rep_info->url($update_title));
           return;
         }
         else {
@@ -148,7 +148,7 @@
       }
       else {
         if (($title // '') eq 'Home') {
-          $self->redirect_to("/$user_id/$project_id/wiki");
+          $self->redirect_to($wiki_rep_info->url);
           return;
         }
         else {
@@ -156,7 +156,7 @@
           $content = $api->get_wiki_page_content($user_id, $project_id, $title);
 
           if (defined $content) {
-            # Convert wiki link to markdonw link
+            # Convert wiki link to markdown link
             $content_md = $api->markdown_wiki($user_id, $project_id, $content);
             $display = 'page';
 
@@ -179,7 +179,7 @@
             $p = '_pages' unless $p;
           }
           else {
-            $self->redirect_to("/$user_id/$project_id/wiki/_pages");
+            $self->redirect_to($wiki_rep_info->url('_pages'));
             return;
           }
         }
@@ -189,9 +189,16 @@
       $display = 'init';
     }
     else {
-      $self->redirect_to("/$user_id/$project_id");
+      $self->redirect_to($wiki_rep_info->repo->url);
       return;
     }
+  }
+
+  # Serve raw objects.
+  if ($display eq 'new' && !$edit && !$new && defined($title) && $title ne '' &&
+      $api->wiki_file_exists($user_id, $project_id, $title)) {
+    $self->redirect_to($wiki_rep_info->url("raw/$title"));
+    return;
   }
 
   my $query = {};
@@ -232,10 +239,10 @@
 
       // Click delete page
       $('#wiki-btn-delete-page').on('click', function () {
-        if (window.confirm('This page is deleted. OK?')) {
+        if (window.confirm('Are you sure you want to delete this page?')) {
           $.post('<%= url_for %>', {op : "ajax-delete", title : "<%= $title %>"}, function (result) {
             if (result.success) {
-              location.href="<%= url_for("/$user_id/$project_id/wiki") %>";
+              location.href="<%= url_for($wiki_rep_info->url) %>";
             }
           });
         }
@@ -255,13 +262,13 @@
 
       <ul class="wiki-count">
         <li>
-          <a href="<%= url_for("/$user_id/$project_id/wiki") %>">
+          <a href="<%= url_for($wiki_rep_info->url) %>">
             %= $api->icon('home');
             Home
           </a>
         </li>
         <li>
-          <a href="<%= url_for("/$user_id/$project_id/wiki/_pages") %>">
+          <a href="<%= url_for($wiki_rep_info->url('_pages')) %>">
             %= $api->icon('note');
             Pages
             <span class="count-label">
@@ -270,7 +277,7 @@
           </a>
         </li>
         <li>
-          <a href="<%= url_for("/$user_id/$project_id/wiki/commits/master") %>">
+          <a href="<%= url_for($wiki_rep_info->url('commits/master')) %>">
             %= $api->icon('git-commit');
             Commits
             <span class="count-label">
@@ -291,14 +298,14 @@
           <ul class="wiki-top-buttons">
             % if ($display eq 'page') {
               <li>
-                <a class="wiki-btn-history" href="<%= url_for("/$user_id/$project_id/wiki/commits/master/$title.md") %>" >
+                <a class="wiki-btn-history" href="<%= url_for($wiki_rep_info->url("commits/master/$title.md")) %>" >
                   %= $api->icon('history');
                   History
                 </a>
               </li>
               % if ($canadmin) {
                 <li>
-                  <a href="<%= url_for("/$user_id/$project_id/wiki/$title/_edit")->query($query) %>">
+                  <a href="<%= url_for($wiki_rep_info->url("$title/_edit"))->query($query) %>">
                     <button class="btn btn-new">
                       %= $api->icon('pencil');
                       Edit
@@ -320,7 +327,7 @@
               % }
               % if ($display ne 'new' && $display ne 'init' && $display ne 'edit') {
                 <li>
-                  <a href="<%= url_for("/$user_id/$project_id/wiki/_new")->query($query) %>">
+                  <a href="<%= url_for($wiki_rep_info->url('_new'))->query($query) %>">
                     <button class="btn btn-green btn-new">Create page</button>
                   </a>
                 </li>
@@ -334,7 +341,7 @@
         % if ($display eq 'init') {
           <h1 class="topic1">Wiki</h1>
           <div>
-            <a href="<%= url_for("/$user_id/$project_id/wiki/_new")->query($query) %>">
+            <a href="<%= url_for($wiki_rep_info->url('_new'))->query($query) %>">
               <button class="btn btn-green btn-new">Create page</button>
             </a>
           </div>
@@ -386,7 +393,7 @@
               </label>
               <div>
                 <span class="wiki-edit-form-cancel-btn">
-                  <button class="btn btn-cancel" type="button" onclick="location.href='<%= url_for("/$user_id/$project_id/wiki/$p") %>'">Cancel</button>
+                  <button class="btn btn-cancel" type="button" onclick="location.href='<%= url_for($wiki_rep_info->url($p)) %>'">Cancel</button>
                 </span>
                 <span class="wiki-edit-form-create-page-btn">
                   <%= submit_button $submit_button_title, class => 'btn btn-green btn-new' %>
@@ -408,7 +415,7 @@
               </div>
             % } elsif ($canadmin && $title ne '_Sidebar' && $title ne '_Footer') {
               <div class="wiki-add-footer">
-                <a href="<%= url_for("/$user_id/$project_id/wiki/_Footer")->query($query) %>">+ Add footer</a>
+                <a href="<%= url_for($wiki_rep_info->url('_Footer'))->query($query) %>">+ Add footer</a>
               </div>
             % }
           </div>
@@ -419,7 +426,7 @@
               </div>
             % } elsif ($canadmin && $title ne '_Sidebar' && $title ne '_Footer') {
               <div class="wiki-add-side-bar">
-                <a href="<%= url_for("/$user_id/$project_id/wiki/_Sidebar")->query($query) %>">+ Add side bar</a>
+                <a href="<%= url_for($wiki_rep_info->url('_Sidebar'))->query($query) %>">+ Add side bar</a>
               </div>
             % }
           </div>
@@ -432,7 +439,7 @@
               <ul class="wiki-list-pages">
                 % for my $page (@$pages) {
                   <li>
-                    <a href="<%= url_for("/$user_id/$project_id/wiki/$page") %>"><%= $page %></a>
+                    <a href="<%= url_for($wiki_rep_info->url($page)) %>"><%= $page %></a>
                   </li>
                 % }
               </ul>


### PR DESCRIPTION
To extend the possible wiki title "syntax" a mapping is intoduced to convert a title to/from a file name: slashes are mapped to unicode division slashs and initial dot to unicode one dot leader.

To support this, wiki url routing in adapted.

As it is possible to create/alter wiki files via git, each of them smust match the following criteria to be considered as a wiki page:
- be in the master branch,
- have a ".md" suffix,
- have a symetric name/title mapping,
- be a regular file located in the top directory,
- not hidden (no initial dot in name).

There are however still undetected problematic titles: those starting with a gitprep url verb (like "commits/") or ending with "/_edit" and those that cannot be represented as an url path.

The get_wiki_pages_count subroutine is also removed as its function can be easily derived from the get_wiki_pages subroutine result.