### PR TITLE
Adjust wiki page titles to a safe character subset

### DIFF
--- a/lib/Gitprep.pm
+++ b/lib/Gitprep.pm
@@ -598,12 +598,6 @@ sub startup {
               # Show pages
               $r->any('/_pages')->to('list-pages' => 1);
 
-              # Show wiki page
-              $r->any('/:title');
-
-              # Edit wiki page
-              $r->any('/:title/_edit')->to(edit => 1);
-
               # Commits
               $r->get('/commits/*rev_file' => sub { shift->render_maybe('/commits') });
 
@@ -624,6 +618,12 @@ sub startup {
 
               # Diff folding
               $r->post('/api/fold/*rev_file' => sub { shift->render_maybe('/api/diff_fold'); });
+
+              # Edit wiki page
+              $r->any('/#title/_edit')->to(edit => 1);
+
+              # Show wiki page
+              $r->any('/#title');
             }
 
             # Commit

--- a/lib/Gitprep/API.pm
+++ b/lib/Gitprep/API.pm
@@ -16,6 +16,17 @@ use Gitprep::Repository;
 
 has 'cntl';
 
+# Replace title characters that have a special meaning in file names and/or URL.
+sub wiki_safe_title {
+  my ($self, $title) = @_;
+
+  $title =~ s/^(.*?)\s*$/$1/; # Trim right.
+  $title =~ s/^\./\x{2024}/;  # No hidden page: use one dot leader.
+  $title =~ s#/#\x{2215}#g;   # Use division slashes.
+  return $title;
+}
+
+# Convert markdown to html with [[...]] wiki links.
 sub markdown_wiki {
   my ($self, $user_id, $project_id, $content) = @_;
 
@@ -30,6 +41,7 @@ sub markdown_wiki {
       $title = $link_text;
     }
 
+    $title = $self->wiki_safe_title($title);
     my $replace = "[$link_text](" . $url_base . "\/$title)";
 
     my $exists_page = $self->exists_wiki_page($user_id, $project_id, $title);
@@ -68,24 +80,22 @@ sub sync_wiki_work {
   }
 }
 
-sub exists_wiki_page {
-  my ($self, $user_id, $project_id, $title) = @_;
+sub wiki_file_exists {
+  my ($self, $user_id, $project_id, $file_name) = @_;
 
   my $wiki_work_rep_info = Gitprep::Repository::Wiki->new($user_id,
     $project_id)->work;
 
-  # File name
-  my $file_name = $title;
-  $file_name =~ s/^ +//;
-  $file_name =~ s/ +$//;
-  $file_name .= '.md';
-
   # File abs name
   my $file_abs_name = $wiki_work_rep_info->work_tree($file_name);
 
-  my $exists = -f encode('UTF-8', $file_abs_name);
+  return -f encode('UTF-8', $file_abs_name);
+}
 
-  return $exists;
+sub exists_wiki_page {
+  my ($self, $user_id, $project_id, $title) = @_;
+
+  return $self->wiki_file_exists($user_id, $project_id, "$title.md");
 }
 
 sub get_wiki_pages {
@@ -101,39 +111,18 @@ sub get_wiki_pages {
 
   # Pages
   my @pages;
-  while (my $file = readdir $dh) {
-    $file = decode('UTF-8', $file);
-    next if $file =~ /^\./;
-    $file =~ s/\.[^\.]+$//;
-    push @pages, $file;
+  while (my $fn = readdir $dh) {
+    $fn = decode('UTF-8', $fn);
+    next if $fn =~ /^\./;
+    next unless $fn =~ /^(.*)\.md$/;
+    next if $self->wiki_safe_title($1) ne $1;
+
+    # Can be a non-regular file.
+    push @pages, $1 if -f encode('UTF-8', $wiki_work_rep_info->work_tree($fn));
   }
 
   @pages = sort { lc $a cmp lc $b } @pages;
-
   return \@pages;
-}
-
-sub get_wiki_pages_count {
-  my ($self, $user_id, $project_id) = @_;
-
-  my $wiki_work_rep_info = Gitprep::Repository::Wiki->new($user_id,
-    $project_id)->work;
-
-  # Open directory
-  my $dir = $wiki_work_rep_info->work_tree;
-  opendir my $dh, $dir
-    or croak "Can't open directory \"$dir\":$!";
-
-  # Pages
-  my $count = 0;
-  while (my $file = readdir $dh) {
-    $file = decode('UTF-8', $file);
-    next if $file =~ /^\./;
-    $file =~ s/\.[^\.]+$//;
-    $count++;
-  }
-
-  return $count;
 }
 
 sub get_wiki_page_content {
@@ -143,20 +132,16 @@ sub get_wiki_page_content {
     $project_id)->work;
 
   # File name
-  my $file_name = $title;
-  $file_name =~ s/^ +//;
-  $file_name =~ s/ +$//;
-  $file_name .= '.md';
+  my $file_name = "$title.md";
 
   # File abs name
   my $file_abs_name = $wiki_work_rep_info->work_tree($file_name);
 
-  unless (-f encode('UTF-8', $file_abs_name)) {
-    return;
-  }
+  my $utf8_name = encode('UTF-8', $file_abs_name);
+  return unless -f $utf8_name;
 
-  open my $fh, '<', encode('UTF-8', $file_abs_name)
-    or die "Can't open file \"" . encode('UTF-8', $file_abs_name) . "\": $!";
+  open my $fh, '<', $utf8_name
+    or die "Can't open file \"$utf8_name\": $!";
 
   my $content = do { local $/; <$fh> };
 
@@ -180,16 +165,14 @@ sub create_wiki_page {
   my $wiki_work_rep_info = $wiki_rep_info->work;
 
   # File name
-  my $file_name = $title;
-  $file_name =~ s/^ +//;
-  $file_name =~ s/ +$//;
-  $file_name .= '.md';
+  my $file_name = "$title.md";
 
   # File abs name
   my $file_abs_name = $wiki_work_rep_info->work_tree($file_name);
+  my $utf8_name = encode('UTF-8', $file_abs_name);
 
-  open my $fh, '>:encoding(UTF-8)', encode('UTF-8', $file_abs_name)
-    or die "Can't open file \"". encode('UTF-8', $file_abs_name) . "\": $!";
+  open my $fh, '>:encoding(UTF-8)', $utf8_name
+    or die "Can't open file \"$utf8_name\": $!";
 
   # Write content to file
   print $fh $content;
@@ -265,26 +248,21 @@ sub rename_and_update_wiki_page {
   my $wiki_work_rep_info = $wiki_rep_info->work;
 
   # Original file name
-  my $original_file_name = $original_title;
-  $original_file_name =~ s/^ +//;
-  $original_file_name =~ s/ +$//;
-  $original_file_name .= '.md';
+  my $original_file_name = "$original_title.md";
 
   # File name
-  my $file_name = $title;
-  $file_name =~ s/^ +//;
-  $file_name =~ s/ +$//;
-  $file_name .= '.md';
+  my $file_name = "$title.md";
 
   # Original file abs name
   my $original_file_abs_name = $wiki_work_rep_info->work_tree($original_file_name);
 
   # File abs name
   my $file_abs_name = $wiki_work_rep_info->work_tree($file_name);
+  my $utf8_name = encode('UTF-8', $file_abs_name);
 
   # Create file
-  open my $fh, '>:encoding(UTF-8)', encode('UTF-8', $file_abs_name)
-    or die "Can't open file \"". encode('UTF-8', $file_abs_name) . "\": $!";
+  open my $fh, '>:encoding(UTF-8)', $utf8_name
+    or die "Can't open file \"$utf8_name\": $!";
 
   # Write content to file
   print $fh $content;
@@ -293,9 +271,10 @@ sub rename_and_update_wiki_page {
   close $fh;
 
   # Delete original file
-  if (-f encode('UTF-8', $original_file_abs_name)) {
-    unlink encode('UTF-8', $original_file_abs_name)
-      or die "Can't delete file \"" . encode('UTF-8', $original_file_abs_name) . "\": $!";
+  my $utf8_original_name = encode('UTF-8', $original_file_abs_name);
+  if (-f $utf8_original_name) {
+    unlink $utf8_original_name
+      or die "Can't delete file \"$utf8_original_name\": $!";
   }
 
   # Check file changes
@@ -321,7 +300,7 @@ sub rename_and_update_wiki_page {
   my @git_rm_cmd = $self->app->git->cmd(
     $wiki_work_rep_info,
     'rm',
-    encode('UTF-8', $original_file_abs_name)
+    $utf8_original_name
   );
 
   Gitprep::Util::run_command(@git_rm_cmd)
@@ -375,16 +354,15 @@ sub delete_wiki_page {
   my $wiki_work_rep_info = $wiki_rep_info->work;
 
   # File name
-  my $file_name = $title;
-  $file_name .= '.md';
+  my $file_name = "$title.md";
 
   # File abs name
   my $file_abs_name = $wiki_work_rep_info->work_tree($file_name);
+  my $utf8_name = encode('UTF-8', $file_abs_name);
 
   # Delete file
-  if (-f encode('UTF-8', $file_abs_name)) {
-    unlink encode('UTF-8', $file_abs_name)
-      or die "Can't delete file \"" . encode('UTF-8', $file_abs_name) . "\": $!";
+  if (-f $utf8_name) {
+    unlink $utf8_name or die "Can't delete file \"$utf8_name\": $!";
   }
 
   # Check file changes
@@ -410,7 +388,7 @@ sub delete_wiki_page {
   my @git_rm_cmd = $self->app->git->cmd(
     $wiki_work_rep_info,
     'rm',
-    encode('UTF-8', $file_abs_name)
+    $utf8_name
   );
 
   Gitprep::Util::run_command(@git_rm_cmd)

--- a/lib/Gitprep/Git.pm
+++ b/lib/Gitprep/Git.pm
@@ -601,7 +601,7 @@ sub blob_size {
 sub check_head_link {
   my ($self, $dir) = @_;
 
-  # Chack head
+  # Check head
   my $head_file = "$dir/HEAD";
   return ((-e $head_file) ||
     (-l $head_file && readlink($head_file) =~ /^refs\/heads\//));

--- a/templates/raw.html.ep
+++ b/templates/raw.html.ep
@@ -10,10 +10,6 @@
   my $rev_file = param('rev_file');
 
   my $is_wiki = (stash('tab') // '') eq 'wiki';
-  my $user_id_project_path = "/$user_id/$project_id";
-  if ($is_wiki) {
-    $user_id_project_path .= '/wiki';
-  }
   my $rep_info = Gitprep::Repository->new($user_id, $project_id);
   $rep_info = $rep_info->wiki if $is_wiki;
 

--- a/templates/wiki.html.ep
+++ b/templates/wiki.html.ep
@@ -1,4 +1,5 @@
 <%
+  use Mojo::JSON qw(encode_json);
   use Gitprep::Repository;
 
   # API
@@ -15,16 +16,18 @@
 
   # Maybe mojolicious bug? In FreeBSD, String is not decoded.
   eval { $title = Encode::decode('UTF-8', $title) };
+  $title = $api->wiki_safe_title($title) if defined $title;
 
   my $project_row_id = $api->get_project_row_id($user_id, $project_id);
 
   my $wiki_rep_info = Gitprep::Repository::Wiki->new($user_id, $project_id);
   my $wiki = -d $wiki_rep_info->root;
   $api->sync_wiki_work($wiki_rep_info) if $wiki;
+  my $pages = [];
+  $pages = $api->get_wiki_pages($user_id, $project_id) if $wiki;
 
   my $content;
   my $content_md;
-  my $pages;
 
   # Session
   my $logined = $api->logined;
@@ -49,11 +52,16 @@
         return;
       }
       elsif ($op eq 'ajax-delete') {
-        $api->delete_wiki_page($user_id, $project_id, $title);
+        my $title_to_delete = param('title-to-delete');
+        eval { $title_to_delete = Encode::decode('UTF-8', $title_to_delete) };
+        my $success = 0;
+        if ($api->wiki_safe_title($title_to_delete) eq $title_to_delete) {
+          $api->delete_wiki_page($user_id, $project_id, $title_to_delete);
+          flash(message => "$title_to_delete deleted");
+          $success = 1;
+        }
 
-        flash(message => "Deleted $title");
-
-        $self->render(json => {success => 1});
+        $self->render(json => {success => $success});
         return;
       }
     }
@@ -80,10 +88,16 @@
         if (!length $update_title) {
           $validation->add_failed(title => 'Page title is empty.');
         }
-        elsif ($title && $title =~ /^_/) {
-          if ($title ne '_Sidebar' && $title ne '_Footer') {
-            $validation->add_failed(title => 'Page title can\'t start with _.');
+        elsif (defined($original_title) &&
+               $api->wiki_safe_title($original_title) ne $original_title) {
+          $validation->add_failed(title => 'No page for original title.');
+        }
+        else {
+          my $t = $api->wiki_safe_title($update_title);
+          if ($t ne $update_title && $t ne ($original_title // '')) {
+            flash(message => 'Title adjusted for URL safeness');
           }
+          $update_title = $t;
         }
 
         if ($validation->is_valid) {
@@ -102,7 +116,7 @@
             $api->create_wiki_page($user_id, $project_id, $update_title, $content, $commit_message);
           }
 
-          $self->redirect_to("/$user_id/$project_id/wiki/$update_title");
+          $self->redirect_to($wiki_rep_info->url($update_title));
           return;
         }
         else {
@@ -118,7 +132,7 @@
   my $content_footer_md;
 
   # Pages count
-  my $pages_count = 0;
+  my $pages_count = @$pages;
 
   # Commits number
   my $commits_number = 0;
@@ -131,7 +145,6 @@
   }
   else {
     if ($wiki) {
-      $pages_count = $api->get_wiki_pages_count($user_id, $project_id);
       $commits_number = app->git->commits_number($wiki_rep_info, 'master');
 
       if ($edit) {
@@ -145,12 +158,10 @@
       }
       elsif ($list_pages) {
         $display = 'list-pages';
-        # Pages
-        $pages = $api->get_wiki_pages($user_id, $project_id);
       }
       else {
         if (($title // '') eq 'Home') {
-          $self->redirect_to("/$user_id/$project_id/wiki");
+          $self->redirect_to($wiki_rep_info->url);
           return;
         }
         else {
@@ -158,7 +169,7 @@
           $content = $api->get_wiki_page_content($user_id, $project_id, $title);
 
           if (defined $content) {
-            # Convert wiki link to markdonw link
+            # Convert wiki link to markdown link
             $content_md = $api->markdown_wiki($user_id, $project_id, $content);
             $display = 'page';
 
@@ -166,14 +177,14 @@
             $exists_sidebar = $api->exists_wiki_page($user_id, $project_id, '_Sidebar');
             if ($exists_sidebar) {
               my $content_sidebar = $api->get_wiki_page_content($user_id, $project_id, '_Sidebar');
-              $content_sidebar_md = $api->markdown($content_sidebar);
+              $content_sidebar_md = $api->markdown_wiki($user_id, $project_id, $content_sidebar);
             }
 
             # Footer
             $exists_footer = $api->exists_wiki_page($user_id, $project_id, '_Footer');
             if ($exists_footer) {
               my $content_footer = $api->get_wiki_page_content($user_id, $project_id, '_Footer');
-              $content_footer_md = $api->markdown($content_footer);
+              $content_footer_md = $api->markdown_wiki($user_id, $project_id, $content_footer);
             }
           }
           elsif ($canadmin) {
@@ -181,7 +192,7 @@
             $p = '_pages' unless $p;
           }
           else {
-            $self->redirect_to("/$user_id/$project_id/wiki/_pages");
+            $self->redirect_to($wiki_rep_info->url('_pages'));
             return;
           }
         }
@@ -191,7 +202,7 @@
       $display = 'init';
     }
     else {
-      $self->redirect_to("/$user_id/$project_id");
+      $self->redirect_to($wiki_rep_info->repo->url);
       return;
     }
   }
@@ -234,10 +245,21 @@
 
       // Click delete page
       $('#wiki-btn-delete-page').on('click', function () {
-        if (window.confirm('This page is deleted. OK?')) {
-          $.post('<%= url_for %>', {op : "ajax-delete", title : "<%= $title %>"}, function (result) {
-            if (result.success) {
-              location.href="<%= url_for("/$user_id/$project_id/wiki") %>";
+        if (window.confirm('Are you sure you want to delete this page?')) {
+          // application/x-www-form-urlencoded content type must be avoided
+          //  here to avoid HTML-style (&) escaping.
+          var data = new FormData();
+          data.append('op', 'ajax-delete');
+          data.append('title-to-delete', <%== encode_json($title) %>);
+          $.post({
+            'url': '<%= url_for %>',
+            'data': data,
+            'processData': false,
+            'contentType': false,
+            'success': function (result) {
+              if (result.success) {
+                location.href="<%= url_for($wiki_rep_info->url) %>";
+              }
             }
           });
         }
@@ -257,13 +279,13 @@
 
       <ul class="wiki-count">
         <li>
-          <a href="<%= url_for("/$user_id/$project_id/wiki") %>">
+          <a href="<%= url_for($wiki_rep_info->url) %>">
             %= $api->icon('home');
             Home
           </a>
         </li>
         <li>
-          <a href="<%= url_for("/$user_id/$project_id/wiki/_pages") %>">
+          <a href="<%= url_for($wiki_rep_info->url('_pages')) %>">
             %= $api->icon('note');
             Pages
             <span class="count-label">
@@ -272,7 +294,7 @@
           </a>
         </li>
         <li>
-          <a href="<%= url_for("/$user_id/$project_id/wiki/commits/master") %>">
+          <a href="<%= url_for($wiki_rep_info->url('commits/master')) %>">
             %= $api->icon('git-commit');
             Commits
             <span class="count-label">
@@ -293,14 +315,14 @@
           <ul class="wiki-top-buttons">
             % if ($display eq 'page') {
               <li>
-                <a class="wiki-btn-history" href="<%= url_for("/$user_id/$project_id/wiki/commits/master/$title.md") %>" >
+                <a class="wiki-btn-history" href="<%= url_for($wiki_rep_info->url("commits/master/$title.md")) %>" >
                   %= $api->icon('history');
                   History
                 </a>
               </li>
               % if ($canadmin) {
                 <li>
-                  <a href="<%= url_for("/$user_id/$project_id/wiki/$title/_edit")->query($query) %>">
+                  <a href="<%= url_for($wiki_rep_info->url("$title/_edit"))->query($query) %>">
                     <button class="btn btn-new">
                       %= $api->icon('pencil');
                       Edit
@@ -322,7 +344,7 @@
               % }
               % if ($display ne 'new' && $display ne 'init' && $display ne 'edit') {
                 <li>
-                  <a href="<%= url_for("/$user_id/$project_id/wiki/_new")->query($query) %>">
+                  <a href="<%= url_for($wiki_rep_info->url('_new'))->query($query) %>">
                     <button class="btn btn-green btn-new">Create page</button>
                   </a>
                 </li>
@@ -336,7 +358,7 @@
         % if ($display eq 'init') {
           <h1 class="topic1">Wiki</h1>
           <div>
-            <a href="<%= url_for("/$user_id/$project_id/wiki/_new")->query($query) %>">
+            <a href="<%= url_for($wiki_rep_info->url('_new'))->query($query) %>">
               <button class="btn btn-green btn-new">Create page</button>
             </a>
           </div>
@@ -388,7 +410,7 @@
               </label>
               <div>
                 <span class="wiki-edit-form-cancel-btn">
-                  <button class="btn btn-cancel" type="button" onclick="location.href='<%= url_for("/$user_id/$project_id/wiki/$p") %>'">Cancel</button>
+                  <button class="btn btn-cancel" type="button" onclick="location.href='<%= url_for($wiki_rep_info->url($p)) %>'">Cancel</button>
                 </span>
                 <span class="wiki-edit-form-create-page-btn">
                   <%= submit_button $submit_button_title, class => 'btn btn-green btn-new' %>
@@ -410,7 +432,7 @@
               </div>
             % } elsif ($canadmin && $title ne '_Sidebar' && $title ne '_Footer') {
               <div class="wiki-add-footer">
-                <a href="<%= url_for("/$user_id/$project_id/wiki/_Footer")->query($query) %>">+ Add footer</a>
+                <a href="<%= url_for($wiki_rep_info->url('_Footer'))->query($query) %>">+ Add footer</a>
               </div>
             % }
           </div>
@@ -421,7 +443,7 @@
               </div>
             % } elsif ($canadmin && $title ne '_Sidebar' && $title ne '_Footer') {
               <div class="wiki-add-side-bar">
-                <a href="<%= url_for("/$user_id/$project_id/wiki/_Sidebar")->query($query) %>">+ Add side bar</a>
+                <a href="<%= url_for($wiki_rep_info->url('_Sidebar'))->query($query) %>">+ Add side bar</a>
               </div>
             % }
           </div>
@@ -434,7 +456,7 @@
               <ul class="wiki-list-pages">
                 % for my $page (@$pages) {
                   <li>
-                    <a href="<%= url_for("/$user_id/$project_id/wiki/$page") %>"><%= $page %></a>
+                    <a href="<%= url_for($wiki_rep_info->url($page)) %>"><%= $page %></a>
                   </li>
                 % }
               </ul>


### PR DESCRIPTION
This is the replacement for PR #251.

Titiles with initial underscore are accepted and such pages are handled as any other. Pages titled `_Sidebar` and `_Footer` also fall in this category, but have a special display use.

This commit also adds wiki links handling in sidebar and footer. 
Regular image/links with relative urls are not properly handled (yet).

I had to use an ajax delete request with content-type multipart/form-data because form-urlencoded escapes ampersands, altering a title containing such characters.

Enjoy it!

