### PR TITLE
Sticky elements and json viewer

### DIFF
--- a/lib/Gitprep/Git.pm
+++ b/lib/Gitprep/Git.pm
@@ -28,6 +28,7 @@ has ext2mimetype => sub {
                          jfif  => 'image/jpeg',
                          jpeg  => 'image/jpeg',
                          jpg   => 'image/jpeg',
+                         json  => 'application/json',
                          md    => 'text/markdown',
                          pdf   => 'application/pdf',
                          pbm   => 'image/x-portable-anymap',

--- a/public/css/common.css
+++ b/public/css/common.css
@@ -4474,3 +4474,81 @@ pre.command-line {
   vertical-align: sub;
   overflow: hidden;
 }
+
+.gp-tree {
+  font-family: monospace;
+}
+
+.gp-tree.root,
+.gp-tree.node {
+  display: inline-flex;
+  flex-direction: column;
+  min-width: 100%;
+}
+
+summary.gp-tree {
+  background-color: #f0f0f0;
+  padding: 2px 3px;
+  border: 1px solid #e0e0e0;
+}
+
+summary.gp-tree:focus {
+  background-color: #c0c0f0;
+}
+
+summary.gp-tree::marker {
+  padding-right: 3px;
+}
+
+details.gp-tree.empty > summary::marker {
+  color: #00000000;
+}
+
+.gp-tree.table {
+  display: table;
+  min-width: 100%;
+  padding-left: 8px;
+  border-spacing: 8px 4px;
+  border-collapse: collapse;
+  border-style: hidden;
+}
+
+.gp-tree.row {
+  display: table-row;
+}
+
+.gp-tree.cell {
+  display: table-cell;
+  border: 1px solid #e0e0e0;
+  padding: 2px 3px;
+  padding-right: 0px;
+}
+
+.gp-tree.key,
+.gp-tree.index {
+  padding-left: 10px;
+  padding-right: 3px;
+}
+
+.gp-tree.index {
+  color: #909090;
+  text-align: end;
+}
+
+.gp-tree.key-text {
+  background-color: #f8f8f8;
+  padding: 3px 3px 6px 3px;
+  position: sticky;
+  top: 0px;
+}
+
+.json-tree-container {
+  border: 1px solid #e0e0e0;
+  padding: 5px 3px;
+  width: 100%;
+}
+
+.json-tree {
+  display: inline-block;
+  min-width: 100%;
+}

--- a/public/css/common.css
+++ b/public/css/common.css
@@ -2780,7 +2780,7 @@ a:hover .btn-delete {
 }
 
 .blame-body-container {
-  overflow-x:scroll;
+  /* overflow-x:scroll;      Handled by gp-xscroll .*/
   border:1px solid #e6e9e6;
   border-radius:0 0 3px 3px;
 }
@@ -2796,9 +2796,14 @@ a:hover .btn-delete {
 
 .blame-body-left {
   padding:3px 7px;
-  vertical-align:middle;
+  vertical-align:top;
   border-left:none;
   border-bottom:none;
+}
+
+.blame-body-sticky {
+  position: sticky;
+  top: 0;
 }
 
 .blame-body-center {

--- a/public/js/gitprep.js
+++ b/public/js/gitprep.js
@@ -397,6 +397,71 @@
     });
   });
 
+  // Add collapse/expand all to a details/summary tree.
+  (function (Tree) {
+    var tree_nodes = function (root) {
+      var nodes = [$(root).get(0)];
+      $(root).children('.gp-tree').each(function (i, el) {
+        nodes = nodes.concat(tree_nodes(el));
+      });
+      return nodes;
+    };
+
+    Tree.expand = function (self) {
+      $(self).closest('details').attr('open', 'true');
+    };
+
+    Tree.collapse = function (self) {
+      $(self).closest('details').removeAttr('open');
+    };
+
+    Tree.expand_all = function (self) {
+      $('summary',
+        tree_nodes($(self).closest('details'))).get().forEach(Tree.expand);
+    };
+
+    Tree.collapse_all = function (self) {
+      $('summary',
+        tree_nodes($(self).closest('details'))).get().forEach(Tree.collapse);
+    };
+
+    Tree.toggle = function (self) {
+      $(self).closest('details').is('[open]')?
+        Tree.collapse_all(self): Tree.expand(self);
+    };
+
+    Tree.init = function(self, expanded) {
+      var summaries = $('summary:not(empty)', tree_nodes(self));
+      summaries.get().forEach(function (el) {
+        if (expanded != undefined) {
+          Tree.collapse(el);
+        }
+        $(el).on('click', function (e) {
+          Tree.toggle(this);
+          this.focus();
+          e.preventDefault();
+        });
+        $(el).on('dblclick', function () {
+          Tree.expand_all(this);
+          this.focus();
+        });
+      });
+      if (expanded != undefined) {
+        var first = summaries.get(0);
+        if (first != undefined && expanded > 0) {
+          Tree.expand(first);
+          if (expanded > 1) {
+            Tree.expand_all(first);
+          }
+        }
+      }
+    };
+
+    $(document).ready(function () {
+      $('.gp-tree.root').each(function (i, el) {Tree.init(el);});
+    });
+  }(Gitprep.Tree = Gitprep.Tree || {}));
+
   // X direction scroller.
   // Use this instead of CSS overflow-x when there are subelements that
   //  should be sticky to an outer vertical scroller.

--- a/public/js/gitprep.js
+++ b/public/js/gitprep.js
@@ -396,4 +396,61 @@
       $(form).prepend(hiddenSubmit);
     });
   });
+
+  // X direction scroller.
+  // Use this instead of CSS overflow-x when there are subelements that
+  //  should be sticky to an outer vertical scroller.
+  // Use attribute gp-xscroll with the desired overflow type.
+  (function (Xscroll) {
+    Xscroll.init = function (el) {
+      var outer = $(el);
+      var ovfl = outer.attr('gp-xscroll');
+      var inner = $('<div></div>').css({
+        position: 'relative',
+        'min-width': '100%'
+      });
+      var scroller = $('<div></div>').css({
+        position: 'relative',
+        width: '100%',
+        'overflow-x': ovfl,
+        'scrollbar-gutter': 'stable',
+      });
+      var scrollcontent = $('<div></div>').css('height', '3px');
+
+      var resize = function () {
+        var clone = inner.clone().css({
+          position: 'absolute',
+          visibility: 'hidden',
+          width: 'auto',
+          maxWidth: 'none',
+          minWidth: '0px',
+          whiteSpace: 'nowrap'
+        });
+        $('body', document).append(clone);
+        var width = clone.get(0).getBoundingClientRect().width;
+        clone.remove();
+        inner.css('width', width);
+        scrollcontent.css('width', width);
+      };
+
+      var scroll = function () {
+        inner.css('left', -scroller.scrollLeft());
+      };
+
+      scroller.append(scrollcontent);
+      inner.append(outer.children());
+      outer.append(inner).append(scroller).css('overflow-x', 'clip');
+
+      var observer = new ResizeObserver(resize);
+      observer.observe(inner.get(0), {box: 'border-box'});
+      scroller.scroll(scroll);
+
+      resize();
+      scroll();
+    };
+
+    $(document).ready(function () {
+      $('[gp-xscroll]').each(function (i, el) {Xscroll.init(el);});
+    });
+  }(Gitprep.Xscroll = Gitprep.Xscroll || {}));
 }(window.Gitprep = window.Gitprep || {}, jQuery));

--- a/templates/blame.html.ep
+++ b/templates/blame.html.ep
@@ -64,6 +64,16 @@
   $commit_comment =~ s/^[\r\n]*(.*?)[\r\n]*$/$1/;
   my $commit_title = $commit->{title};
 
+  # Compute commmit summary row spans.
+  my $firstline;
+  for my $line (@$blame_lines) {
+    unless ($line->{before_same_commit}) {
+      $firstline = $line;
+      $firstline->{rowspan} = 0;
+    }
+    $firstline->{rowspan}++;
+  }
+
   # Color
   my $colors = [
     '#ffeca7',
@@ -117,7 +127,7 @@
         </ul>
       </div>
     </div>
-    <div class="blame-body-container">
+    <div class="blame-body-container" gp-xscroll="auto">
       <table class="blame-body">
         % for my $line (@$blame_lines) {
           <%
@@ -139,31 +149,33 @@
             $separator = '' unless !$line->{before_same_commit} && $line->{number} != 1;
           %>
           <tr id="L<%= $line->{number} %>" class="<%== $separator %>">
-            <td class="blame-body-left" nowrap style="border-right:2px solid <%= $hot_color %>;">
-              % if (!$line->{before_same_commit}) {
-                <div class="blame-summary-container">
-                  <div class="blame-summary">
-                    % my $tooltip = join "\n", $summary, substr($blame_commit, 0, 7);
-                    <a href="<%= url_for("$user_project_path/commit/$blame_commit") %>" title="<%= $tooltip %>">
-                      <%= $summary_short %>
-                    </a>
-                  </div>
-                  <div class="blame-commit-id">
-                    % if ($line->{chain}) {
-                      % $tooltip = 'Blame prior to change ' . substr($blame_commit, 0, 7);
-                      <a href="<%= url_for("$user_project_path/blame/$parent/$parent_filename") %>" title="<%= $tooltip %>">
-                        %= $api->icon('versions');
+            % if (!$line->{before_same_commit}) {
+              <td class="blame-body-left" nowrap style="border-right:2px solid <%= $hot_color %>;" rowspan="<%= $line->{rowspan} %>">
+                <div class="blame-body-sticky">
+                  <div class="blame-summary-container">
+                    <div class="blame-summary">
+                      % my $tooltip = join "\n", $summary, substr($blame_commit, 0, 7);
+                      <a href="<%= url_for("$user_project_path/commit/$blame_commit") %>" title="<%= $tooltip %>">
+                        <%= $summary_short %>
                       </a>
-                    % }
+                    </div>
+                    <div class="blame-commit-id">
+                      % if ($line->{chain}) {
+                        % $tooltip = 'Blame prior to change ' . substr($blame_commit, 0, 7);
+                        <a href="<%= url_for("$user_project_path/blame/$parent/$parent_filename") %>" title="<%= $tooltip %>">
+                          %= $api->icon('versions');
+                        </a>
+                      % }
+                    </div>
+                  </div>
+                  <div class="blame-author">
+                    <span title="<%= $line->{author_email} %>"><%= $line->{author} %></span>
+                    authored
+                    %= $api->age_element($line->{author_time});
                   </div>
                 </div>
-                <div class="blame-author">
-                  <span title="<%= $line->{author_email} %>"><%= $line->{author} %></span>
-                  authored
-                  %= $api->age_element($line->{author_time});
-                </div>
-              % }
-            </td>
+              </td>
+            % }
             <td class="blame-body-center" nowrap>
               <%= $line->{number} %>
             </td>

--- a/templates/blob/application/json.html.ep
+++ b/templates/blob/application/json.html.ep
@@ -1,0 +1,133 @@
+<%
+  use Mojo::DOM;
+  use Mojo::JSON qw(decode_json);
+
+  # API
+  my $api = gitprep_api;
+
+  # Git 
+  my $git = $self->app->git;
+
+  # Blob parameters
+  my $p = stash('blob_params');
+  my $rep_info = $p->{rep_info};
+
+  my $lines = $git->blob($rep_info, $p->{rev}, $p->{file});
+  return unless @$lines;
+
+  # Set-up header fields.
+  # Although having an application mime type, json is text.
+  $p->{header_left} = $api->plural('lines', scalar(@$lines), 'No');
+  $p->{buttons} = '<li><a class=btn btn-small" href="' . url_for($rep_info->url("blob/$p->{rev}/$p->{file}"))->query(mime => 'text') . '">Code</a></li>';
+  $p->{buttons} .= '<li><a class=btn btn-small" href="' . url_for($rep_info->url("blame/$p->{rev}/$p->{file}")) . '">Blame</a></li>';
+
+  my $json = decode_json(join "\n", @$lines);
+  return unless defined $lines;
+
+  local *JSON_to_DOM = sub {
+    local *escape_string = sub {
+      my ($s, $delim) = @_;
+      $delim //= '"';
+      my $d = $delim;
+
+      my %map = (
+        "\b" => '\\b',
+        "\f" => '\\f',
+        "\n" => '\\n',
+        "\r" => '\\r',
+        "\t" => '\\t',
+        '\\' => '\\\\',
+        '-' => "\x{2011}",    # Non-breaking hyphen.
+        ' ' => "\x{00A0}",    # Non-paddable space.
+      );
+
+      for my $c (split //, $s) {
+        if (defined $map{$c}) {
+          $c = $map{$c};
+        }
+        elsif ($c eq $delim) {
+          $c = "\\$c";
+        }
+        elsif (ord($c) < 0x20) {
+          $c = sprintf('\\u%04X', ord($c));
+        }
+        $d .= $c;
+      }
+
+      return "$d$delim";
+    };
+
+    local *details_with_summary = sub {
+      my ($labels, $values, $label_kind, $summary_text) = @_;
+      my $details = $api->DOM_element('details');
+      $api->DOM_add_class($details, 'empty') unless @$labels;
+      my $summary = $api->DOM_element('summary', class => 'gp-tree',
+        $api->DOM_text($summary_text));
+      $details->append_content($summary);
+      if (@$labels) {
+        my $table = $api->DOM_element('div', class => 'gp-tree table');
+        for my $i (0 .. @$labels - 1) {
+          my $row = $api->DOM_element('div', class => 'gp-tree row');
+          my $key_text = $api->DOM_element('div',
+                                             class => 'gp-tree key-text',
+            $api->DOM_text($labels->[$i]));
+          $row->append_content($api->DOM_element('div',
+            class => "gp-tree cell $label_kind", $key_text));
+          my $cell = JSON_to_DOM($values->[$i]);
+          $api->DOM_add_class($cell, 'cell');
+          $row->append_content($cell);
+          $table->append_content($row);
+        }
+        $details->append_content($table);
+      }
+      return $details;
+    };
+
+    my ($node) = @_;
+    my $dom;
+
+    if (!defined $node) {
+      $dom = $api->DOM_element('div', class => 'null', $api->DOM_text('null'));
+    }
+    elsif (!ref $node) {
+      $dom = $api->DOM_element('div');
+      if ($node =~ /^-?(?:\d+(?:\.\d*)?|\.\d+)(?:[Ee][+-]\d+)?$/) {
+        $api->DOM_add_class($dom, 'number');
+      }
+      else {
+        $api->DOM_add_class($dom, 'string');
+        $node = escape_string($node);
+      }
+      $dom->append_content($api->DOM_text($node));
+    }
+    elsif ('JSON::PP::Boolean' eq ref $node) {
+      $dom = $api->DOM_element('div', class => 'boolean',
+                               $api->DOM_text($node? 'true': 'false'));
+    }
+    elsif ('ARRAY' eq ref $node) {
+      $dom = details_with_summary([0 .. @$node - 1], $node, 'index', '[]');
+      $api->DOM_add_class($dom, 'array');
+    }
+    else {
+      # HASH.
+      my @labels = (sort(keys %$node));
+      my @values = (map $node->{$_}, @labels);
+      @labels = (map escape_string($_), @labels);
+      $dom = details_with_summary(\@labels, \@values, 'key', '{}');
+      $api->DOM_add_class($dom, 'object');
+    }
+
+    $api->DOM_add_class($dom, 'gp-tree node');
+    return $dom;
+  };
+
+  my $tree = $api->DOM_element('div', class => 'gp-tree root',
+     id => 'json-tree', JSON_to_DOM($json));
+  my $html = $api->DOM_render($tree);
+%>
+
+<div class="json-tree-container" gp-xscroll="auto">
+  <div class="json-tree">
+    <%= $html %>
+  </div>
+</div>


### PR DESCRIPTION
Hi Yuki,
This PR adds sticky commit summaries to blame pages and a json-specific blob viewer. More details in the commit comments.

To try blame, navigate to `gitprep/README.md` (in example) and blame it. Then you'll see the first column is now sticky when you scroll vertically. Horizontal scroll is still there and now achieved by Javascript.

To try json, navigate to a `*.json` file. Click/doubleclick on element arrow marker(s) to expand/collapse the element. If displayed data is lengthy, you always see the element path at the top of the screen when you scroll it.

Regards,
Patrick