### PR TITLE
Notify more

### DIFF
--- a/gitprep.conf.example
+++ b/gitprep.conf.example
@@ -112,3 +112,22 @@ listen=http://127.0.0.1:10020
 
 ;;; Authentication password.
 ; sasl_password=LetsOpenIt
+
+;;; SSL kind.
+;;; Set to 'ssl' for implicit SSL or 'starttls' for explicit TLS.
+; ssl=starttls
+
+;;;;; SSL parameters.
+;;;;; See https://metacpan.org/pod/IO::Socket::SSL.
+
+;;; Trusted CAs.
+;;; Use SSL_ca_file if CAs are concatenaed in a single file, SSL_ca_path for
+;;;  as CA's directory.
+; SSL_ca_file=/etc/pki/tls/certs/ca-bundle.crt
+
+;;; Client certificate.
+; SSL_cert_file=/etc/pki/tls/certs/gitprep.crt
+
+;;; Client certificate key.
+;;; Warning: access should be blocked for non-gitprep users.
+; SSL_key_file=/etc/pki/tls/private/gitprep.key

--- a/gitprep.conf.example
+++ b/gitprep.conf.example
@@ -11,6 +11,7 @@
 ;;; It can be set either to a listening URL or a reverse proxy URL linking to
 ;;; the root of the gitprep service. The userinfo, query and fragment parts are
 ;;; ignored.
+;;; Not defining it disables notifications.
 site_url=https://please.change.me
 
 ;;; SSH port (default: 22)

--- a/lib/Gitprep.pm
+++ b/lib/Gitprep.pm
@@ -808,10 +808,24 @@ sub startup {
   # E-mail transport.
   if ($conf->{mail}{from}) {
     if ($conf->{smtp}{hosts}) {
+      # SMTP mail: build constructor parameters.
       my $c = $conf->{smtp};
       my %args = map {$_ => $c->{$_}} keys %$c;
+
+      # Convert hosts to array.
       my @hosts = split(' ', $c->{hosts});
       $args{hosts} = \@hosts;
+
+      # Move SSL-specific options into a sub-structure.
+      my $ssl_options = {};
+      for my $key (keys %args) {
+        if ($key =~ /^SSL_/) {
+          $ssl_options->{$key} = $args{$key};
+          delete $args{$key};
+        }
+      }
+      $args{ssl_options} = $ssl_options if $ssl_options;
+
       $self->{mailtransport} = Email::Sender::Transport::SMTP->new(%args);
     }
     else {

--- a/lib/Gitprep/API.pm
+++ b/lib/Gitprep/API.pm
@@ -1214,29 +1214,31 @@ sub notify_subscribed {
       row_id => $sender_row_id
     })->one;
 
-  # Repository owner email address.
-  my $ownermail = $self->app->dbi->model('user')->select('email',
+  # Repository owner.
+  my $owner = $self->app->dbi->model('user')->select(['email', 'notify'],
     where => {
       id => $rep_info->user
-    })->value;
+    })->one;
 
   # Subscriptions.
   my $subscriptions = $self->app->dbi->model('subscription')->select(
     ['subscription__user.email', 'reason'],
     where => {
-      issue => $issue_row_id 
+      issue => $issue_row_id,
+      'subscription__user.notify' => 1
     })->all;
 
   # Watchers.
   my $watchers = $self->app->dbi->model('watch')->select(
     ['watch__user.email'],
     where => {
-      project => $self->get_project_row_id($rep_info)
+      project => $self->get_project_row_id($rep_info),
+      'watch__user.notify' => 1
     })->all;
 
   # Merge results.
   my %recipients = (
-    $ownermail => 'O',
+    $owner->{notify}? ($owner->{email} => 'O'): (),
     (map {$_->{email} => 'W'} @$watchers),
     (map {$_->{email} => $_->{reason}} @$subscriptions)
   );

--- a/lib/Gitprep/API.pm
+++ b/lib/Gitprep/API.pm
@@ -562,6 +562,8 @@ sub markdown {
   my $tree = $params{tree};
   my $site_url = $params{site_url};
 
+  my %users = map {$_ => 1} @{$self->app->dbi->model('user')->select('id')->values};
+
   local *replace_link = sub {
     my %m = (@_);
 
@@ -612,6 +614,15 @@ sub markdown {
       $r = "<span class=\"wiki-link-no-title\" title=\"Non-existent page\">$r</span>"
         unless $self->wiki_page_exists($rep_info, $url);
       return $r;
+    }
+
+    # Mentioned user.
+    # @user.
+    if ($m{marker} eq '@') {
+      return $m{match} unless defined $users{$m{user}};
+      my $r = $self->cntl->url_for("/$m{user}");
+      $r = $r->to_abs($site_url) if $site_url;
+      return "<span class=\"markdown-mentioned\">[\@$m{user}]($r)</span>";
     }
 
     # <img> tag.
@@ -680,7 +691,9 @@ sub markdown {
       # Wiki link.
       #  [[Link text|Title]]
       #  [[Title]]
-      (?<marker>\[\[)(?<text>[^\]\|]+?)(?:\|(?<url>[^\[\]]+?))?\]\]
+      (?<marker>\[\[)(?<text>[^\]\|]+?)(?:\|(?<url>[^\[\]]+?))?\]\]|
+      # Mentioned user.
+      (?<![a-zA-Z0-9_-])(?<marker>\@)(?<user>[a-zA-Z0-9_-]+)
     ))@replace_link(%+)@egmx;
   }
 
@@ -751,7 +764,7 @@ sub mentioned {
 
   # Scan message for @<username>s and return an array of them.
 
-  while ($message =~ /@([a-zA-Z0-9_\-]+)/g) {
+  while ($message =~ /(?:^|[^a-z0-9_\-])@([a-z0-9_\-]+)/gi) {
     $users{$1} = 1;
   }
   my @result = keys %users;

--- a/lib/Gitprep/API.pm
+++ b/lib/Gitprep/API.pm
@@ -1206,7 +1206,7 @@ sub notify_subscribed {
   my $user = $rep_info->user;
   my $project = $rep_info->project;
 
-  $self->app->{mailtransport} || return;
+  $self->app->{mailtransport} && $self->app->{site_url} or return;
 
   # Sender id, name and email address.
   my $sender = $self->app->dbi->model('user')->select(['id', 'name', 'email'],

--- a/lib/Gitprep/API.pm
+++ b/lib/Gitprep/API.pm
@@ -1269,8 +1269,7 @@ sub notify_subscribed {
   # Avoid multi-recipient mails as sent data can be personalized.
   for my $email (keys %recipients) {
     my $html = $self->cntl->render_to_string('/api/notify',
-      user => $user,
-      project => $project,
+      rep_info => $rep_info,
       path_suffix => $path_suffix,
       message => $message,
       message_id => $message_id,

--- a/lib/Gitprep/API.pm
+++ b/lib/Gitprep/API.pm
@@ -1203,42 +1203,50 @@ sub notify_subscribed {
 
   $self->app->{mailtransport} || return;
 
+  # Sender id, name and email address.
+  my $sender = $self->app->dbi->model('user')->select(['id', 'name', 'email'],
+    where => {
+      row_id => $sender_row_id
+    })->one;
+
+  # Repository owner email address.
+  my $ownermail = $self->app->dbi->model('user')->select('email',
+    where => {
+      id => $rep_info->user
+    })->value;
+
   # Subscriptions.
   my $subscriptions = $self->app->dbi->model('subscription')->select(
     ['subscription__user.email', 'reason'],
-    where => $self->app->dbi->where(
-      clause => ['and', ':user{!=}', ':issue{=}'],
-      param => {user => $sender_row_id, issue => $issue_row_id}
-    ))->all;
+    where => {
+      issue => $issue_row_id 
+    })->all;
 
   # Watchers.
   my $watchers = $self->app->dbi->model('watch')->select(
     ['watch__user.email'],
-    where => $self->app->dbi->where(
-      clause => ['and', ':user{!=}', ':project{=}'],
-      param => {
-        user => $sender_row_id,
-        project => $self->get_project_row_id($rep_info)
-      }
-    ))->all;
+    where => {
+      project => $self->get_project_row_id($rep_info)
+    })->all;
 
   # Merge results.
-  my %recipients = ((map {$_->{email} => 'W'} @$watchers),
-                    (map {$_->{email} => $_->{reason}} @$subscriptions));
+  my %recipients = (
+    $ownermail => 'O',
+    (map {$_->{email} => 'W'} @$watchers),
+    (map {$_->{email} => $_->{reason}} @$subscriptions)
+  );
 
   # Filter out unsubscribed.
-  my @recipients = grep {$recipients{$_} ne 'U';} keys(%recipients);
+  %recipients = (map {$_ => $recipients{$_}}
+    grep {($self->notify_reason($recipients{$_}))[1]} keys %recipients);
 
-  # Sender name.
-  my $sender_name = $self->app->dbi->model('user')->select('name',
-    where => {
-      row_id => $sender_row_id
-    })->value;
+  # Do not send back to sender.
+  delete $recipients{$sender->{email}};
 
   # Convert markdown message to HTML.
   $message = $self->markdown(
     $message,
-    Gitprep::Repository->new($user, $project),
+    $rep_info,
     rev => $rev,
     site_url => $self->app->{site_url}
   );
@@ -1254,18 +1262,19 @@ sub notify_subscribed {
 
   # Build visible sender and recipient email addresses.
   my $conf = $self->app->config->{mail};
-  my $from = "$sender_name <$conf->{from}>";
+  my $from = ($sender->{name} || $sender->{id}) . " <$conf->{from}>";
   my $to = 'undisclosed-recipients:;';
   $to = "$user/$project <$conf->{to}>" if $conf->{to};
 
   # Avoid multi-recipient mails as sent data can be personalized.
-  for my $email (@recipients) {
+  for my $email (keys %recipients) {
     my $html = $self->cntl->render_to_string('/api/notify',
       user => $user,
       project => $project,
       path_suffix => $path_suffix,
       message => $message,
-      message_id => $message_id
+      message_id => $message_id,
+      reason => $recipients{$email}
     )->to_string;
     my $plain = $html2plain->parse($html);
     my $top = MIME::Entity->build(From => $from,

--- a/lib/Gitprep/API.pm
+++ b/lib/Gitprep/API.pm
@@ -1166,6 +1166,35 @@ sub subscribe_mentioned {
   }
 }
 
+sub notify_reason {
+  my ($self, $code) = @_;
+
+  my %reasons = (
+    'C' => 'commented',
+    'N' => 'authored the thread',
+    'M' => 'were mentioned',
+    'O' => 'own the repository',
+    'S' => 'subscribed',
+    'W' => 'watch the repository'
+  );
+
+  my $reason_text;
+  my $subscribed = 0;
+
+  if (!defined $code) {
+    $reason_text = "didn't subscribed";
+  }
+  elsif ($code eq 'U') {
+    $reason_text = 'unsubscribed';
+  }
+  else {
+    $subscribed = 1;
+    $reason_text = $reasons{$code};
+  }
+
+  return ($reason_text, $subscribed);
+}
+
 sub notify_subscribed {
   my ($self, $rep_info, $rev, $title, $sender_row_id, $message,
       $message_id, $path_suffix, $issue_row_id) = @_;

--- a/lib/Gitprep/API.pm
+++ b/lib/Gitprep/API.pm
@@ -1240,14 +1240,22 @@ sub notify_subscribed {
                  Charset => 'UTF-8',
                  Data => encode('UTF-8', $plain)
     );
-    Email::Sender::Simple->send(
-      $top->stringify,
-      {
-        transport => $self->app->{mailtransport},
-        from => $conf->{from},
-        to => $email
-      }
-    );
+
+    # Send e-mail. Avoid crashing in case of send problem.
+    eval {
+      Email::Sender::Simple->send(
+        $top->stringify,
+        {
+          transport => $self->app->{mailtransport},
+          from => $conf->{from},
+          to => $email
+        }
+      );
+    };
+    if ($@) {
+      $self->app->log->error('Cannot send e-mail: configuration error or mail server down');
+      $self->app->log->error($@);
+    }
   }
 }
 

--- a/lib/Gitprep/API.pm
+++ b/lib/Gitprep/API.pm
@@ -748,7 +748,12 @@ sub markdown {
       i => [qw( class )],
       u => [qw( class )],
       s => [qw( class )],
-      strike => [qw( class )]
+      strike => [qw( class )],
+      svg  => [ qw( width height viewbox xmlns ) ],
+      circle => [ qw( style cx cy r stroke stroke-width fill ) ],
+      path => [ qw( style d fill stroke ) ],
+      rect => [ qw( style x y width height fill ) ],
+      image => [ qw( x y width height href ) ]
     },
     uri_schemes => [ undef, 'http', 'https', 'mailto' ]
   );

--- a/lib/Gitprep/API.pm
+++ b/lib/Gitprep/API.pm
@@ -1197,7 +1197,7 @@ sub notify_reason {
 
 sub notify_subscribed {
   my ($self, $rep_info, $rev, $title, $sender_row_id, $message,
-      $message_id, $path_suffix, $issue_row_id) = @_;
+      $link, $issue_row_id, $action) = @_;
   my $user = $rep_info->user;
   my $project = $rep_info->project;
 
@@ -1270,9 +1270,10 @@ sub notify_subscribed {
   for my $email (keys %recipients) {
     my $html = $self->cntl->render_to_string('/api/notify',
       rep_info => $rep_info,
-      path_suffix => $path_suffix,
+      link => $link,
       message => $message,
-      message_id => $message_id,
+      sender_id => $sender->{id},
+      action => $action,
       reason => $recipients{$email}
     )->to_string;
     my $plain = $html2plain->parse($html);

--- a/lib/Gitprep/Image.pm
+++ b/lib/Gitprep/Image.pm
@@ -221,4 +221,93 @@ sub image_formats {
   return Imager->read_types;
 }
 
+sub image_as_svg {
+  my $self = shift;
+  my %args = @_;
+  require Imager;
+  require MIME::Base64;
+
+  my $data = $args{data};
+  my $scale = $args{scale};
+  my $type = 'svg';
+  my $img;
+  my $width, $height;
+  my %svgattrs;
+  my $inner;
+
+  if ($args{file}) {
+    open my $fh, '<:raw', $args{file} or return;
+    read $fh, $data, -s $fh;
+    close $fh;
+  }
+
+  return unless $data;
+
+  if ($data =~ m#^\s*<svg((?:\s+[^>="\s]+="[^"]*")*?)\s*>(.*)\s*</svg>\s*$#is) {
+    # Data are already in svg format.
+    $inner = $2;
+    my $dummy = $1;
+    $dummy =~ s/\s+([^>="\s]+)="([^"]*)"/$svgattrs{lc($1)} = $2/egs;
+    my $viewbox = $svgattrs{viewbox};
+    return unless $viewbox;     # No way to determine actual dimensions.
+    (undef, undef, $width, $height) = split /\s+|\s*,\s*/, $viewbox;
+  }
+  else {
+    $img = $data;
+    $img = Imager->new(data => $data) unless 'Imager' eq ref $data;
+    return unless $img;
+    $type = lc($img->type);
+    $type = 'png' unless $type =~ /^(?:jpe?g|png)$/;
+    $width = $img->getwidth;
+    $height = $img->getheight;
+  }
+
+  # Handle scaling.
+  unless ($scale) {
+    $scale = 1;
+    if ($args{width}) {
+      $scale = $args{width} / $width;
+    }
+    elsif ($args{height}) {
+      $scale = $args{height} / $height;
+    }
+  }
+
+  # Recompute the final dimensions.
+  my $newwidth = $width * $scale;
+  my $newheight = $height * $scale;
+
+  if ($type ne 'svg') {
+    # Resize pixel image if scale shrinks it.
+    if ($scale < 1) {
+      $img = $img->scale(xpixels => $newwidth, ypixels => $newheight);
+      $scale = 1;
+      $width = $newwidth;
+      $height = $newheight;
+    }
+
+    # Get the image data.
+    $img->write(data => \$inner, type => $type);
+    $inner = MIME::Base64::encode_base64($inner, '');
+    $inner = "<image href=\"data:image/$type;base64,$inner\"></image>";
+
+    # Synthesize the svg tag attributes.
+    $svgattrs{viewbox} = "0 0 $width $height";
+    $svgattrs{xmlns} = 'http://www.w3.org/2000/svg';
+  }
+
+  $svgattrs{xmlns} = $args{xmlns} if exists $args{xmlns};
+
+  # Update dimensions according to effective scaling.
+  $svgattrs{width} = "${newwidth}px" if exists($svgattrs{width}) || exists $args{width};
+  $svgattrs{height} = "${newheight}px" if exists($svgattrs{height}) || exists $args{height};
+
+  # Build final svg image.
+  my $svg = '<svg ' . join('', map {
+    defined($svgattrs{$_})? " $_=\"$svgattrs{$_}\"": ''
+  } keys %svgattrs);
+  return "$svg>$inner</svg>";
+}
+
+
 1;

--- a/public/css/common.css
+++ b/public/css/common.css
@@ -252,6 +252,17 @@ a.wiki-btn-history:hover {
   color:#e0162e;
 }
 
+.markdown-mentioned {
+  color: #000;
+  font-weight: bold;
+}
+
+.markdown-mentioned a,
+.markdown-mentioned a:visited {
+  text-decoration: inherit;
+  color: inherit;
+}
+
 .wiki-add-footer a {
   color:#99c;
 }

--- a/public/css/common.css
+++ b/public/css/common.css
@@ -248,21 +248,6 @@ a.wiki-btn-history:hover {
   border-radius:3px;
 }
 
-.wiki-link-no-title a {
-  color:#e0162e;
-}
-
-.markdown-mentioned {
-  color: #000;
-  font-weight: bold;
-}
-
-.markdown-mentioned a,
-.markdown-mentioned a:visited {
-  text-decoration: inherit;
-  color: inherit;
-}
-
 .wiki-add-footer a {
   color:#99c;
 }
@@ -4475,15 +4460,6 @@ pre.command-line {
   text-align: center;
   font-size: 130%;
   font-weight: bold;
-}
-
-.avatar {
-  box-shadow: 0 0 0 1px #d0d0d0;
-  border: 0px none;
-  border-radius: 50%;
-  background-color: #f0f0f0;
-  vertical-align: sub;
-  overflow: hidden;
 }
 
 .gp-tree {

--- a/public/css/embedded.css
+++ b/public/css/embedded.css
@@ -17,15 +17,12 @@
   color: #e0162e;
 }
 
-.markdown-mentioned {
-  color: #000;
-  font-weight: bold;
-}
-
+.markdown-mentioned,
 .markdown-mentioned a,
 .markdown-mentioned a:visited {
+  color: #000;
+  font-weight: bold;
   text-decoration: inherit;
-  color: inherit;
 }
 
 .notify-footer {

--- a/public/css/embedded.css
+++ b/public/css/embedded.css
@@ -1,0 +1,35 @@
+/* Minimal gitprep CSS for embedding.
+ * It mainly provides rules for markdown-generated HTML and e-mails.
+ * To save objects size, do not include rules here that do not need to be
+ *  embedded.
+ */
+
+.avatar {
+  box-shadow: 0 0 0 1px #d0d0d0;
+  border: 0px none;
+  border-radius: 50%;
+  background-color: #f0f0f0;
+  vertical-align: sub;
+  overflow: hidden;
+}
+
+.wiki-link-no-title a {
+  color: #e0162e;
+}
+
+.markdown-mentioned {
+  color: #000;
+  font-weight: bold;
+}
+
+.markdown-mentioned a,
+.markdown-mentioned a:visited {
+  text-decoration: inherit;
+  color: inherit;
+}
+
+.notify-footer {
+  color:#666;
+  font-size: small;
+  -webkit-text-size-adjust: none;
+}

--- a/public/css/embedded.css
+++ b/public/css/embedded.css
@@ -33,3 +33,8 @@
   font-size: small;
   -webkit-text-size-adjust: none;
 }
+
+.notify-avatar {
+  display: inline-block;
+  vertical-align: middle;
+}

--- a/setup_database
+++ b/setup_database
@@ -64,6 +64,7 @@ my @tables = (
       {name => 'salt'},
       {name => 'name'},
       {name => 'show_email', type => 'integer'},
+      {name => 'notify', type => 'integer', default => 1},
       {name => 'avatar', type => 'blob'},
       {name => 'bio'},
       {name => 'url'},

--- a/templates/api/notify.html.ep
+++ b/templates/api/notify.html.ep
@@ -8,9 +8,11 @@
   my $path_suffix = stash('path_suffix');
   my $message = stash('message');
   my $message_id = stash('message_id');
+  my $reason = stash('reason');
 
   my $link = url_for("/$user/$project/$path_suffix")->fragment($message_id);
   $link = $link->to_abs(app->{site_url}) if app->{site_url};
+  $reason = ($api->notify_reason($reason))[0];
 
 
   # Get the css styles to embed from local file.
@@ -38,6 +40,7 @@
       % if (app->{site_url}) {
         <a href="<%= $link %>">View it on Gitprep</a><br />
       % }
+    You are receiving this because you <%= $reason %>.
     </p>
   </body>
 </html>

--- a/templates/api/notify.html.ep
+++ b/templates/api/notify.html.ep
@@ -12,7 +12,7 @@
   my $action = stash('action');
   my $reason = stash('reason');
 
-  $link = $link->to_abs(app->{site_url}) if app->{site_url};
+  $link = $link->to_abs(app->{site_url}) unless $link->is_abs;
   $reason = ($api->notify_reason($reason))[0];
 
   # Get the sender's avatar as an inline svg.
@@ -61,10 +61,8 @@
     <div><%== $message %></div>
     <p class="notify-footer">
       &mdash;<br />
-      % if (app->{site_url}) {
-        <a href="<%= $link %>">View it on Gitprep</a><br />
-      % }
-    You are receiving this because you <%= $reason %>.
+      <a href="<%= $link %>">View it on Gitprep</a><br />
+      You are receiving this because you <%= $reason %>.
     </p>
   </body>
 </html>

--- a/templates/api/notify.html.ep
+++ b/templates/api/notify.html.ep
@@ -4,12 +4,12 @@
 
   # Arguments.
   my $rep_info = stash('rep_info');
-  my $path_suffix = stash('path_suffix');
   my $message = stash('message');
-  my $message_id = stash('message_id');
+  my $link = stash('link');
+  my $sender_id = stash('sender_id');
+  my $action = stash('action');
   my $reason = stash('reason');
 
-  my $link = url_for($rep_info->url($path_suffix)->fragment($message_id);
   $link = $link->to_abs(app->{site_url}) if app->{site_url};
   $reason = ($api->notify_reason($reason))[0];
 
@@ -33,6 +33,9 @@
     <%== $css %>
   </head>
   <body>
+    <div>
+      <b><%= $sender_id %></b> <%== $action %>
+    </div>
     <div><%== $message %></div>
     <p class="notify-footer">
       &mdash;<br />

--- a/templates/api/notify.html.ep
+++ b/templates/api/notify.html.ep
@@ -49,10 +49,14 @@
   </head>
   <body>
     <div>
-      % if (defined $avatar) {
-        <span class="avatar notify-avatar"><%== $avatar %></span>
-      % }
-      <b><%= $sender_id %></b> <%== $action %>
+      <a class="markdown-mentioned"
+         href="<%= url_for("/$sender_id")->to_abs(app->{site_url}) %>">
+        % if (defined $avatar) {
+          <span class="avatar notify-avatar"><%== $avatar %></span>
+        % }
+        <%= $sender_id %>
+      </a>
+      <%== $action %>
     </div>
     <div><%== $message %></div>
     <p class="notify-footer">

--- a/templates/api/notify.html.ep
+++ b/templates/api/notify.html.ep
@@ -9,11 +9,35 @@
   my $message = stash('message');
   my $message_id = stash('message_id');
 
-  my $link = url_for("/$user/$project/$path_suffix")->fragment($message_id)->to_abs;
+  my $link = url_for("/$user/$project/$path_suffix")->fragment($message_id);
+  $link = $link->to_abs(app->{site_url}) if app->{site_url};
+
+
+  # Get the css styles to embed from local file.
+  my $css = '';
+  open my $fh, '<', app->home->rel_file('public/css/embedded.css');
+  if ($fh) {
+    $css = do { local $/; <$fh> };
+    close $fh;
+    # Compress.
+    $css =~ s#/\*.*?\*/##gs;            # Strip off comments.
+    $css =~ s/^\s*(.*?)\s*$/$1/gm;      # Trim.
+    $css =~ s/\n+/\n/gs;                # Remove empty lines.
+    $css = "<style>$css</style>";
+  }
 %>
 
-<div><%== $message %></div>
-<p style="font-size:small;-webkit-text-size-adjust:none;color:#666;">
-  &mdash;<br />
-  <a href="<%= $link %>">View it on Gitprep</a>
-</p>
+<html>
+  <head>
+    <%== $css %>
+  </head>
+  <body>
+    <div><%== $message %></div>
+    <p class="notify-footer">
+      &mdash;<br />
+      % if (app->{site_url}) {
+        <a href="<%= $link %>">View it on Gitprep</a><br />
+      % }
+    </p>
+  </body>
+</html>

--- a/templates/api/notify.html.ep
+++ b/templates/api/notify.html.ep
@@ -3,14 +3,13 @@
   my $api = gitprep_api;
 
   # Arguments.
-  my $user = stash('user');
-  my $project = stash('project');
+  my $rep_info = stash('rep_info');
   my $path_suffix = stash('path_suffix');
   my $message = stash('message');
   my $message_id = stash('message_id');
   my $reason = stash('reason');
 
-  my $link = url_for("/$user/$project/$path_suffix")->fragment($message_id);
+  my $link = url_for($rep_info->url($path_suffix)->fragment($message_id);
   $link = $link->to_abs(app->{site_url}) if app->{site_url};
   $reason = ($api->notify_reason($reason))[0];
 

--- a/templates/api/notify.html.ep
+++ b/templates/api/notify.html.ep
@@ -1,4 +1,6 @@
 <%
+  use Gitprep::Image;
+
   # API
   my $api = gitprep_api;
 
@@ -13,6 +15,19 @@
   $link = $link->to_abs(app->{site_url}) if app->{site_url};
   $reason = ($api->notify_reason($reason))[0];
 
+  # Get the sender's avatar as an inline svg.
+  my $avatar = app->dbi->model('user')->select('avatar',
+    where => {id => $sender_id}
+  )->value;
+  if (defined $avatar) {
+    $avatar = Gitprep::Image->identicon($sender_id) unless $avatar;
+    $avatar = Gitprep::Image->image_as_svg(
+      data => $avatar,
+      width => 14,
+      height => 14,
+      xmlns => undef
+    );
+  }
 
   # Get the css styles to embed from local file.
   my $css = '';
@@ -34,6 +49,9 @@
   </head>
   <body>
     <div>
+      % if (defined $avatar) {
+        <span class="avatar notify-avatar"><%== $avatar %></span>
+      % }
       <b><%= $sender_id %></b> <%== $action %>
     </div>
     <div><%== $message %></div>

--- a/templates/api/subscribe.html.ep
+++ b/templates/api/subscribe.html.ep
@@ -42,7 +42,7 @@
       because you <%= $reason_text %>
     % }
   </span>.
-  % if (!$api->app->{mailtransport}) {
+  % if (!$api->app->{mailtransport} || !$api->app->{site_url}) {
     <p style="margin-top: 3px;">Notifications are currently disabled.</p>
   % }
 </div>

--- a/templates/api/subscribe.html.ep
+++ b/templates/api/subscribe.html.ep
@@ -24,28 +24,7 @@
     where => {user => $user_row_id, project => $project_row_id}
   )->value;
 
-  my %reasons = (
-    'S' => 'subscribed',
-    'O' => 'own the repository',
-    'N' => 'authored the thread',
-    'C' => 'commented',
-    'M' => 'were mentioned',
-    'W' => 'watch the repository'
-  );
-
-  my $reason_text;
-  my $subscribed = 0;
-
-  if (!defined $reason) {
-    $reason_text = "didn't subscribed";
-  }
-  elsif ($reason eq 'U') {
-    $reason_text = 'unsubscribed';
-  }
-  else {
-    $subscribed = 1;
-    $reason_text = $reasons{$reason};
-  }
+  my ($reason_text, $subscribed) = $api->notify_reason($reason);
 %>
 
 <button id="subscribe-btn" class="subscription-btn">

--- a/templates/api/subscribe.html.ep
+++ b/templates/api/subscribe.html.ep
@@ -24,6 +24,11 @@
     where => {user => $user_row_id, project => $project_row_id}
   )->value;
 
+  my $notify = app->dbi->model('user')->select(
+    'notify',
+     where => {'row_id' => $user_row_id}
+   )->value;
+
   my ($reason_text, $subscribed) = $api->notify_reason($reason);
 %>
 
@@ -37,13 +42,22 @@
   % }
 </button>
 <div class="notif-reason">
-  <span>You’re <%= $subscribed? '': 'not ' %>receiving notifications
-    % if (defined $reason_text) {
-      because you <%= $reason_text %>
-    % }
-  </span>.
+  % if (!$subscribed || $notify) {
+    <span>You’re <%= $subscribed? '': 'not ' %>receiving notifications
+      % if (defined $reason_text) {
+        because you <%= $reason_text %>
+      % }
+    </span>.
+  % } else {
+    <span>You
+      % if (defined $reason_text) {
+        <%= $reason_text %>, but you
+      % }
+      globally disabled all notifications
+    </span>.
+  % }
   % if (!$api->app->{mailtransport} || !$api->app->{site_url}) {
-    <p style="margin-top: 3px;">Notifications are currently disabled.</p>
+    <p style="margin-top: 3px;">Notifications are currently not supported by this Gitprep instance.</p>
   % }
 </div>
 

--- a/templates/blob/image/tiff.html.ep
+++ b/templates/blob/image/tiff.html.ep
@@ -1,6 +1,7 @@
 <%
   use MIME::Base64;
   use Imager;
+  use Gitprep::Image;
 
   # API
   my $api = gitprep_api;
@@ -23,13 +24,11 @@
   $p->{header_left} .= "$type " unless $type eq 'direct';
   $p->{header_left} .= $colormodel unless ($colormodel // 'unknown') eq 'unknown';
 
-  # Convert image to PNG data.
-  my $buffer;
-  $img->write(data => \$buffer, type => 'png');
-
-  # Encapsulate in SVG.
-  my $picture = encode_base64($buffer, '');
-  $picture = "<svg viewBox=\"0 0 $width $height\" width=\"$width\" height=\"$height\"><image href=\"data:image/png;base64,$picture\"></image></svg>";
+  my $picture = Gitprep::Image->image_as_svg(
+    data => $img,
+    width => 0,         # Force setting default width.
+    xmlns => undef
+  );
 %>
 
 <div class="blob-image">

--- a/templates/compare.html.ep
+++ b/templates/compare.html.ep
@@ -210,6 +210,15 @@
 
           app->dbi->model('issue_message')->insert($new_issue_message);
 
+          # Notifications.
+          my $link = url_for($base_rep_info->url("pull/$issue_number"))->fragment('comment-1');
+          $link = $link->to_abs(app->{site_url}) if app->{site_url};
+          my $action = "created a new pull request <a href=\"$link\"> ($base_user_id/$base_project_id#$issue_number)</a>";
+          $api->notify_subscribed($base_rep_info, $base_branch,
+                                  "$new_issue->{title} (#$issue_number)",
+                                  $session_user_row_id, $message, $link,
+                                  $new_issue_row_id, $action);
+
           $self->redirect_to("/$base_user_id/$base_project_id/pull/$issue_number");
           return;
         });

--- a/templates/compare.html.ep
+++ b/templates/compare.html.ep
@@ -630,7 +630,7 @@
         <%= hidden_field rev => $base_branch %>
         <div class="issue-add-comment-header">
           <div class="issue-add-comment-title">
-            <%= text_field 'title' => $commits->[0]{title_short} %>
+            <%= text_field 'title' => $commits->[0]{title_short}, placeholder => 'Give a title to this pull request' %>
           </div>
           <div class="issue-message-write-tab issue-add-comment-header-tab"><a href="javascript:void(0)">Write</a></div>
           <div class="issue-message-preview-tab issue-add-comment-header-tab"><a class="disable" href="javascript:void(0)">Preview</a></div>

--- a/templates/compare.html.ep
+++ b/templates/compare.html.ep
@@ -210,6 +210,9 @@
 
           app->dbi->model('issue_message')->insert($new_issue_message);
 
+          # Subscriptions.
+          $api->subscribe_mentioned($new_issue_row_id, $message);
+
           # Notifications.
           my $link = url_for($base_rep_info->url("pull/$issue_number"))->fragment('comment-1');
           $link = $link->to_abs(app->{site_url}) if app->{site_url};

--- a/templates/issue.html.ep
+++ b/templates/issue.html.ep
@@ -246,11 +246,13 @@
 
         # Notifications.
         my $issuekind = $issue->{pull_request}? 'pull': 'issues';
+        my $link = url_for($base_rep_info->url("$issuekind/$issue_number"))->fragment("comment-$msgno");
+        $link = $link->to_abs(app->{site_url}) if app->{site_url};
+        my $action = "left a comment <a href=\"$link\"> ($base_user_id/$base_project_id#$issue_number)</a>";
         $api->notify_subscribed($base_rep_info, $base_branch,
                                 "$issue->{title} (#$issue_number)",
-                                $api->session_user_row_id, $message,
-                                "comment-$msgno", "$issuekind/$issue_number",
-                                $issue->{row_id});
+                                $api->session_user_row_id, $message, $link,
+                                $issue->{row_id}, $action);
         $self->redirect_to;
         return;
       }

--- a/templates/issues/new.html.ep
+++ b/templates/issues/new.html.ep
@@ -97,10 +97,12 @@
           $api->subscribe_mentioned($new_issue_row_id, $message);
 
           # Notifications.
+          my $link = url_for($rep_info->url("issues/$issue_number"))->fragment('comment-1');
+          $link = $link->to_abs(app->{site_url}) if app->{site_url};
+          my $action = "opened a new issue <a href=\"$link\"> ($user_id/$project_id#$issue_number)</a>";
           $api->notify_subscribed($rep_info, $rev, "$title (#$issue_number)",
-                                  $session_user_row_id, $message,
-                                  "comment-1", "issues/$issue_number",
-                                  $new_issue_row_id);
+                                  $session_user_row_id, $message, $link,
+                                  $new_issue_row_id, $action);
         });
 
         $self->redirect_to("/$user_id/$project_id/issues/$issue_number");

--- a/templates/issues/new.html.ep
+++ b/templates/issues/new.html.ep
@@ -134,7 +134,7 @@
       <%= hidden_field rev => $rev %>
       <div class="issue-add-comment-header">
         <div class="issue-add-comment-title">
-          <%= text_field 'title' %>
+          <%= text_field 'title', placeholder => 'Give a title to this issue' %>
         </div>
         <div class="issue-message-write-tab issue-add-comment-header-tab"><a href="javascript:void(0)">Write</a></div>
         <div class="issue-message-preview-tab issue-add-comment-header-tab"><a class="disable" href="javascript:void(0)">Preview</a></div>

--- a/templates/layouts/common.html.ep
+++ b/templates/layouts/common.html.ep
@@ -20,6 +20,7 @@
     % my $title = stash('title');
     <title><%= $title ? "$title \x{b7} Gitprep" : 'Gitprep' %></title>
     %= stylesheet '/css/common.css', rel => 'stylesheet', media => 'screen';
+    %= stylesheet '/css/embedded.css', rel => 'stylesheet', media => 'screen';
     % for my $stylesheet (@$stylesheets) {
       %= stylesheet $stylesheet;
     % }

--- a/templates/user-settings.html.ep
+++ b/templates/user-settings.html.ep
@@ -100,6 +100,7 @@
         }
       }
       $user->{show_email} = param('show_email')? 1: 0;
+      $user->{notify} = param('notify')? 1: 0;
       $user->{avatar} = decode_base64(param('picture')) if defined param('picture');
       $social = $self->every_param('social') // [];
       $social = [map {$_ =~ /^\s*(.*?)\s*$/; $1? $1: ()} @$social];
@@ -153,6 +154,15 @@
                     Your name may appear around Gitprep where you contribute or
                     are mentioned. You can remove it at any time.
                   </div>
+                </li>
+                <li>
+                  <div class="field-label">
+                    Notifications
+                  </div>
+                  <input type="checkbox" name="notify" <%== $user->{notify}? ' checked="yes"': '' %>" />
+                  <span class="explain">
+                    Check this if you want to receive notifications.
+                  </span>
                 </li>
                 <li>
                   <div class="field-label">

--- a/templates/user-settings.html.ep
+++ b/templates/user-settings.html.ep
@@ -36,8 +36,8 @@
         if (!$picture) {
           push @$errors, 'Invalid or unsupported image data';
         } else {
+          $avatar = Gitprep::Image->image_as_svg(data => $picture, xmlns => undef);
           $picture = encode_base64($picture, '');
-          $avatar = "<svg viewBox=\"0 0 $size $size\"><image href=\"data:image/png;base64,$picture\"></image></svg>";
         }
       } else {
         $avatar = Gitprep::Image->identicon($user_id);


### PR DESCRIPTION
Hi Yuki,

This is a bunch of commits related to notifications.
In short:
- SSL/TLS support for SMTP mail,
- mentioned user links in markdown,
- augmented notification e-mail content,
- notifications on pull requests,
- a per-user global notification enabling switch,
- CSS embedding in e-mails (new CSS file)

This requires running `setup_database`.

As some SMTP servers can be slow, bulk-email sending may add an important delay to issue comment submissions: the proper solution would be to have a detached task queue doing this job in parallel without blocking the main application. This is a TODO !

Have fun!
Patrick

P.S.: I've also silently fixed a few bugs this week-end :-)